### PR TITLE
Added section on setting environment variables

### DIFF
--- a/doc/Module_builder.md
+++ b/doc/Module_builder.md
@@ -2,12 +2,18 @@
 
 The KBase Module Builder is an application that helps developers initialize, compile, test, and run KBase modules. This document details how to install and use it.
 
-# Obtain prerequisites
+# Obtain and install prerequisites
 
 1. Java JDK (http://java.oracle.com)
 2. ant (http://ant.apache.org/)
   - Mac OS: Homebrew or MacPorts are the easiest ways to install
   - Linux: Depends on distribution
+
+# Set environment variables
+
+Set JAVA_HOME to the directory where you installed JDK. If you're not sure where that is, the command /usr/libexec/java_home will tell you.
+    setenv JAVA_HOME `/usr/libexec/java_home`
+Also, add to your PATH the directory where you installed ant.
 
 # Get the git repos
 
@@ -20,10 +26,9 @@ The KBase Module Builder is an application that helps developers initialize, com
     make
 
 You should now have the kb-mobu program built in kb_sdk/bin. It will be helpful to add this to your execution path:
-
     export PATH=$(pwd)/bin:$PATH
 
-(or some variant for your OS - consider adding this to your .profile or .bashrc)
+(or some variant for your OS -- consider adding this to your .profile or .bashrc)
 
 # kb-mobu init
 

--- a/doc/Module_builder.md
+++ b/doc/Module_builder.md
@@ -9,8 +9,10 @@ The KBase Module Builder is an application that helps developers initialize, com
   - Mac OS: Homebrew or MacPorts are the easiest ways to install
   - Linux: Depends on distribution
 3. plack:
-   cpanm --sudo Task::Plack
+   sudo cpanm --sudo Task::Plack
    (If you don't have cpanm, install from http://search.cpan.org/~miyagawa/App-cpanminus-1.7039/lib/App/cpanminus.pm#INSTALL)
+4. Bio::KBase
+   sudo cpanm Bio::KBase
 
 # Set environment variables
 

--- a/doc/Module_builder.md
+++ b/doc/Module_builder.md
@@ -8,6 +8,9 @@ The KBase Module Builder is an application that helps developers initialize, com
 2. ant (http://ant.apache.org/)
   - Mac OS: Homebrew or MacPorts are the easiest ways to install
   - Linux: Depends on distribution
+3. plack:
+   cpanm --sudo Task::Plack
+   (If you don't have cpanm, install from http://search.cpan.org/~miyagawa/App-cpanminus-1.7039/lib/App/cpanminus.pm#INSTALL)
 
 # Set environment variables
 
@@ -69,13 +72,13 @@ To build and run the module examples, you'll need to do the following.
 
 2. Start the Mockup job service. This is a small web service that is a part of the SDK, and used for testing for now (note - this is under construction).
 
-    cd kb_sdk/test_scripts/ee_mock_service
+    cd ../test_scripts/ee_mock_service
     ./start_service.sh
 
 3. Start your module's server. The Perl example is given below
 
-    cd MyModule/scripts
-    ./start_perl_server.sh > server.log 2>&1 &
+    cd ../../MyModule/scripts
+    sh ./start_perl_server.sh > server.log 2>&1 &
 
 4. Now you can run your tests against your running server. The example test directory contains some basic client tests, but others can be added here.
 

--- a/doc/Module_builder.md
+++ b/doc/Module_builder.md
@@ -8,11 +8,6 @@ The KBase Module Builder is an application that helps developers initialize, com
 2. ant (http://ant.apache.org/)
   - Mac OS: Homebrew or MacPorts are the easiest ways to install
   - Linux: Depends on distribution
-3. plack:
-   sudo cpanm --sudo Task::Plack
-   (If you don't have cpanm, install from http://search.cpan.org/~miyagawa/App-cpanminus-1.7039/lib/App/cpanminus.pm#INSTALL)
-4. Bio::KBase
-   sudo cpanm Bio::KBase
 
 # Set environment variables
 
@@ -90,4 +85,3 @@ To build and run the module examples, you'll need to do the following.
 # kb-mobu compile
 
 The compile option is the primary service compiler, and makes up the bulk of the example Makefile.
-


### PR DESCRIPTION
Hit a wall at line 53 -- kb-mobu init doesn't seem to accept command-line options.

[Pixel:~/sdk/kb_sdk] nomi% kb-mobu init -e -l Perl MyModule
Command Line Argument Error: Unknown option: -e

For more help and usage information, run:
    kb-mobu help

[Pixel:~/sdk/kb_sdk] nomi% kb-mobu init --help
Command Line Argument Error: Unknown option: --help

For more help and usage information, run:
    kb-mobu help

[Pixel:~/sdk/kb_sdk] nomi% kb-mobu init -h
Command Line Argument Error: Unknown option: -h

For more help and usage information, run:
    kb-mobu help