### PR TITLE
Async way is now default for Perl and Python server side generated code.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -21,6 +21,6 @@
 	<classpathentry kind="lib" path="../jars/lib/jars/apache_commons/commons-collections-3.2.1.jar"/>
 	<classpathentry kind="lib" path="../jars/lib/jars/jcommander/jcommander-1.48.jar"/>
 	<classpathentry kind="lib" path="kbase-common-temp.jar"/>
-	<classpathentry kind="lib" path="/kb/dev_container/modules/jars/lib/jars/snakeyaml/snakeyaml-1.11.jar"/>
+	<classpathentry kind="lib" path="../jars/lib/jars/snakeyaml/snakeyaml-1.11.jar"/>
 	<classpathentry kind="output" path="eclipse-classes"/>
 </classpath>

--- a/src/java/us/kbase/mobu/compiler/RunCompileCommand.java
+++ b/src/java/us/kbase/mobu/compiler/RunCompileCommand.java
@@ -126,7 +126,7 @@ public class RunCompileCommand {
                 perlClientSide, perlClientName, perlServerSide, perlServerName, 
                 perlImplName, perlPsgiName, pyClientSide, pyClientName, 
                 pyServerSide, pyServerName, pyImplName, perlEnableRetries, newStyle, 
-                ip, output, perlMakefile, pyMakefile);
+                ip, output, perlMakefile, pyMakefile, newStyle);
     }
 	
 	

--- a/src/java/us/kbase/templates/perl_client.vm.properties
+++ b/src/java/us/kbase/templates/perl_client.vm.properties
@@ -268,6 +268,60 @@ sub ${method.name}_check {
                         method_name => '${method.name}_check');
     }
 }
+#if( $method.could_be_sync )
+sub ${method.name}_sync
+{
+    my($self, @args) = @_;
+
+# Authentication: ${method.authentication}
+
+    if ((my $n = @args) != ${method.arg_count})
+    {
+    Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+                                   "Invalid argument count for function ${method.name} (received $n, expecting ${method.arg_count})");
+    }
+#if( $method.arg_count > 0 )
+    {
+    my(${method.arg_vars}) = @args;
+
+    my @_bad_arguments;
+#foreach( $param in $method.params )
+        (${param.validator}) or push(@_bad_arguments, "Invalid type for argument ${param.index} \\"${param.name}\\" (value was \\"${param.perl_var}\\")");
+#end
+        if (@_bad_arguments) {
+        my $msg = "Invalid arguments passed to ${method.name}:\\n" . join("", map { "\\t$_\\n" } @_bad_arguments);
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+                                   method_name => '${method.name}');
+    }
+    }
+#end
+
+    my $result = $self->{client}->call($self->{url}, $self->{headers}, {
+    method => "${module.module_name}.${method.name}",
+    params => \\@args,
+    });
+    if ($result) {
+    if ($result->is_error) {
+        Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+                           code => $result->content->{error}->{code},
+                           method_name => '${method.name}',
+                           data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+                          );
+    } else {
+#if( $method.ret_count > 0 )
+        return wantarray ? @{$result->result} : $result->result->[0];
+#else
+        return;
+#end
+    }
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method ${method.name}",
+                        status_line => $self->{client}->status_line,
+                        method_name => '${method.name}',
+                       );
+    }
+}
+#end ## of if-could-be-sync
 #else ## of if-any-async
 sub ${method.name}
 {

--- a/src/java/us/kbase/templates/perl_server.vm.properties
+++ b/src/java/us/kbase/templates/perl_server.vm.properties
@@ -61,6 +61,16 @@ our %method_authentication = (
 #end
 
 #if( $any_async )
+our %sync_methods = (
+#foreach( $module in $modules )
+#foreach( $method in $module.methods )
+#if( (! $method.async) || $method.could_be_sync )
+        '${method.name}' => 1,
+#end
+#end
+#end
+);
+
 our %async_run_methods = (
 #foreach( $module in $modules )
 #foreach( $method in $module.methods )
@@ -344,6 +354,7 @@ sub call_method {
 #if( $any_async )
             my $job_srv_cl;
             my $job_id;
+            my $cli = $self->_plack_req_header("CLI");
             if (exists($async_run_methods${empty_escaper}{$method})) {
                 my $orig_full_method = $async_run_methods${empty_escaper}{$method};
                 my %run_job_params = (
@@ -367,7 +378,7 @@ sub call_method {
                 } else {
                     @result = ($job_state);
                 }
-            } else {
+            } elsif ($cli || exists($sync_methods${empty_escaper}{$method})) {
 #end
             $self->log($Bio::KBase::Log::INFO, $ctx, "start method", $tag);
             local $SIG${empty_escaper}{__WARN__} = sub {
@@ -379,6 +390,8 @@ sub call_method {
             @result = $module->$method(@{ $data->{arguments} });
             $self->log($Bio::KBase::Log::INFO, $ctx, "end method", $tag);
 #if( $any_async )
+            } else {
+                die "Method ".$method." cannot be run synchronously";
             }
 #end
         };
@@ -915,7 +928,8 @@ unless (caller) {
     }
 #end
     my %headers = (
-        "Authorization" => $token
+        "Authorization" => $token,
+        "CLI" => "1"
     );
     my $server = ${server_package_name}->new(
         instance_dispatch => { @dispatch },

--- a/src/java/us/kbase/templates/python_client.vm.properties
+++ b/src/java/us/kbase/templates/python_client.vm.properties
@@ -208,6 +208,23 @@ class ${module.module_name}(object):
 #else
                 return
 #end
+#if( $method.could_be_sync )
+    def ${method.name}_sync(self${comma_args}, json_rpc_context = None):
+        if json_rpc_context and type(json_rpc_context) is not dict:
+            raise ValueError('Method ${method.name}: argument json_rpc_context is not type dict as required.')
+#if( $method.ret_count == 1 )
+        resp = self._call('${module.module_name}.${method.name}',
+                          [${method.args}], json_rpc_context)
+        return resp[0]
+#elseif( $method.ret_count > 1 )
+        resp = self._call('${module.module_name}.${method.name}',
+                          [${method.args}], json_rpc_context)
+        return resp
+#else
+        self._call('${module.module_name}.${method.name}',
+                   [${method.args}], json_rpc_context)
+#end
+#end ## of if-could-be-sync
 #else ## of if-async
 
     def ${method.name}(self${comma_args}, json_rpc_context = None):

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -74,13 +74,16 @@ class JSONObjectEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 #if( $any_async )
-
+sync_methods = {}
 async_run_methods = {}
 async_check_methods = {}
 #foreach( $module in $modules )
 #foreach( $method in $module.methods )
 async_run_methods['${module.module_name}.${method.name}_async'] = ['${module.module_name}', '${method.name}']
 async_check_methods['${module.module_name}.${method.name}_check'] = ['${module.module_name}', '${method.name}']
+#if( (! $method.async) || $method.could_be_sync )
+sync_methods['${module.module_name}.${method.name}'] = True
+#end
 #end
 #end
 
@@ -485,11 +488,15 @@ class Application(object):
                                 respond = {'version': '1.1', 'result': [job_state], 'id': req['id']}
                                 rpc_result = json.dumps(respond, cls=JSONObjectEncoder)
                                 status = '200 OK'
-                    else:
+                    elif method_name in sync_methods:
                         self.log(log.INFO, ctx, 'start method')
                         rpc_result = self.rpc_service.call(ctx, req)
                         self.log(log.INFO, ctx, 'end method')
                         status = '200 OK'
+                    else:
+                        err = ServerError()
+                        err.data = 'Method ' + method_name + ' cannot be run synchronously'
+                        raise err
 #else
                     self.log(log.INFO, ctx, 'start method')
                     rpc_result = self.rpc_service.call(ctx, req)
@@ -640,6 +647,7 @@ def process_async_cli(input_file_path, output_file_path, token):
         ctx['token'] = token
 #end
     ctx['rpc_context'] = req['context']
+    ctx['CLI'] = 1
     resp = None
     try:
         resp = application.rpc_service.call_py(ctx, req)


### PR DESCRIPTION
Now any method without async declaration is runnable from command line. If method is declared as async explicitly then such method is runnable from command line only. (It's all true for Perl and Python server code yet)