### PR TITLE
Support to build sdkbase image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /dist
 /temp_test
 /eclipse-classes/
+/sdkbase/ssl
 

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ ANT ?= ant
 ANT_OPTIONS =
 
 # make sure our make test works
-.PHONY : test
+.PHONY : test sdkbase
 
 
-default: compile
+default: compile sdkbase
 
 ifeq ($(TOP_DIR_NAME), dev_container)
 ##############################
@@ -71,6 +71,10 @@ deploy-scripts:
 	  	 exit 1; \
 	fi;
 	$(ANT) deploy_bin -DBIN_TARGET=$(TARGET)/bin -DBIN_LIB_TARGET=$(TARGET)/lib
+
+sdkbase:
+	cd sdkbase && ./makeconfig
+	docker build -t kbase/sdkbase:latest sdkbase
 
 test: submodule-init
 	@# todo: remove perl typecomp tests and add it as a separate target

--- a/doc/Docker_deployment.md
+++ b/doc/Docker_deployment.md
@@ -38,30 +38,3 @@ Note: this has only been tested in OS X.
 2. Add proper JSON input to work/input.json
 2. docker run --name mymodulename -v work:/kb/module/work mymodulename async
 3. Look in work/output.json for output
-
-For docker related development questions and common issues, a great resource is this article: [Docker for Development: Common Problems and Solutions](https://medium.com/@rdsubhas/docker-for-development-common-problems-and-solutions-95b25cae41eb?_tmc=Diy2bNEQqG5t8sSbcMW6T5Us4KCmgsInjBviObh0atg&mkt_tok=3RkMMJWWfF9wsRonuqTMZKXonjHpfsX57u8lXqCzlMI%2F0ER3fOvrPUfGjI4AS8VqI%2BSLDwEYGJlv6SgFQ7LMMaZq1rgMXBk%3D#.pwg4oa1ew)
-
-
-## FAQ
-
-#### During the Docker build, I get this error: IOError: [Errno 13] Permission denied: '/tmp/kbase/[ModuleName]/.git/config.lock'
-
-Add a .dockerignore file to skip .git files.  You should also skip any other OS specific files.  Soon we will try to provide a standard .dockerignore and .gitignore files generated as part of the kb-mobu init.
-
-####  How can I see the tools that are available in the KBase base image?
-
-If you have deplbase pulled down locally, you can do this...
-
-        docker run -it —rm kbsae/deplbase:latest
-        
-Then you can navigate around to see what is present.  You can also look directly at the docker file used to build the runtime here: https://hub.docker.com/r/kbase/runtime/~/dockerfile/
-
-There are some tools also installed by the standard KBase services, but if you have a specific version of a tool you would like to use, then it would probably be best to install it yourself.
-
-#### Are the KBase boostrap repository third party dependency scripts being used in the current Docker base image setup?
-
-Not entirely, so don't use the bootstrap repo as a reference for what is installed.
-
-#### Are there any size constraints for the images that we create?
-
-Not yet, but there will be one soon.  Ideally keep images under 10GB.  If you have large amounts of reference data that will not fit within the 10GB, then please contact us directly.  We are working on alternative ways to handle reference data that are still being tested and documented, so do not add this data directly to your image.

--- a/doc/Docker_deployment.md
+++ b/doc/Docker_deployment.md
@@ -38,3 +38,30 @@ Note: this has only been tested in OS X.
 2. Add proper JSON input to work/input.json
 2. docker run --name mymodulename -v work:/kb/module/work mymodulename async
 3. Look in work/output.json for output
+
+For docker related development questions and common issues, a great resource is this article: [Docker for Development: Common Problems and Solutions](https://medium.com/@rdsubhas/docker-for-development-common-problems-and-solutions-95b25cae41eb?_tmc=Diy2bNEQqG5t8sSbcMW6T5Us4KCmgsInjBviObh0atg&mkt_tok=3RkMMJWWfF9wsRonuqTMZKXonjHpfsX57u8lXqCzlMI%2F0ER3fOvrPUfGjI4AS8VqI%2BSLDwEYGJlv6SgFQ7LMMaZq1rgMXBk%3D#.pwg4oa1ew)
+
+
+## FAQ
+
+#### During the Docker build, I get this error: IOError: [Errno 13] Permission denied: '/tmp/kbase/[ModuleName]/.git/config.lock'
+
+Add a .dockerignore file to skip .git files.  You should also skip any other OS specific files.  Soon we will try to provide a standard .dockerignore and .gitignore files generated as part of the kb-mobu init.
+
+####  How can I see the tools that are available in the KBase base image?
+
+If you have deplbase pulled down locally, you can do this...
+
+        docker run -it —rm kbsae/deplbase:latest
+        
+Then you can navigate around to see what is present.  You can also look directly at the docker file used to build the runtime here: https://hub.docker.com/r/kbase/runtime/~/dockerfile/
+
+There are some tools also installed by the standard KBase services, but if you have a specific version of a tool you would like to use, then it would probably be best to install it yourself.
+
+#### Are the KBase boostrap repository third party dependency scripts being used in the current Docker base image setup?
+
+Not entirely, so don't use the bootstrap repo as a reference for what is installed.
+
+#### Are there any size constraints for the images that we create?
+
+Not yet, but there will be one soon.  Ideally keep images under 10GB.  If you have large amounts of reference data that will not fit within the 10GB, then please contact us directly.  We are working on alternative ways to handle reference data that are still being tested and documented, so do not add this data directly to your image.

--- a/sdkbase/Dockerfile
+++ b/sdkbase/Dockerfile
@@ -1,0 +1,15 @@
+FROM kbase/deplbase:latest
+
+# Update kb_sdk at build time
+ONBUILD RUN \
+  . /kb/dev_container/user-env.sh && \
+  cd /kb/dev_container/modules && \
+  rm -rf jars && \
+  git clone https://github.com/kbase/jars && \
+  rm -rf kb_sdk && \
+  git clone https://github.com/kbase/kb_sdk -b develop && \
+  cd /kb/dev_container/modules/jars && \
+  make && make deploy && \
+  cd /kb/dev_container/modules/kb_sdk && \
+  make && make deploy
+

--- a/sdkbase/create_certs
+++ b/sdkbase/create_certs
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+[ -e ./ssl ] || mkdir ./ssl
+
+[ -z $PUBLIC_ADDRESS ] && PUBLIC_ADDRESS="kbase.us"
+export PUBLIC_ADDRESS
+
+# Create certs for development deploy
+if [ -e ./ssl/proxy.key ] ; then
+  echo "Skipping proxy cert"
+else
+  openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout ./ssl/proxy.key -out ./ssl/proxy.crt -config openssl.cnf  -batch
+fi
+  
+if [ -e ./ssl/narrative.key ] ; then
+  echo "Skipping narrative cert"
+else
+  cp ./ssl/proxy.key ./ssl/narrative.key
+  cp ./ssl/proxy.crt ./ssl/narrative.crt
+fi

--- a/sdkbase/makeconfig
+++ b/sdkbase/makeconfig
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+docker run --rm --entrypoint cat kbase/deplbase:latest /kb/deployment/deployment.cfg > cluster.ini
+./create_certs

--- a/sdkbase/openssl.cnf
+++ b/sdkbase/openssl.cnf
@@ -1,0 +1,355 @@
+#
+# OpenSSL example configuration file.
+# This is mostly being used for generation of certificate requests.
+#
+
+# This definition stops the following lines choking if HOME isn't
+# defined.
+HOME			= .
+RANDFILE		= $ENV::HOME/.rnd
+
+# Extra OBJECT IDENTIFIER info:
+#oid_file		= $ENV::HOME/.oid
+oid_section		= new_oids
+
+# To use this configuration file with the "-extfile" option of the
+# "openssl x509" utility, name here the section containing the
+# X.509v3 extensions to use:
+# extensions		= 
+# (Alternatively, use a configuration file that has only
+# X.509v3 extensions in its main [= default] section.)
+
+[ new_oids ]
+
+# We can add new OIDs in here for use by 'ca', 'req' and 'ts'.
+# Add a simple OID like this:
+# testoid1=1.2.3.4
+# Or use config file substitution like this:
+# testoid2=${testoid1}.5.6
+
+# Policies used by the TSA examples.
+tsa_policy1 = 1.2.3.4.1
+tsa_policy2 = 1.2.3.4.5.6
+tsa_policy3 = 1.2.3.4.5.7
+
+####################################################################
+[ ca ]
+default_ca	= CA_default		# The default ca section
+
+####################################################################
+[ CA_default ]
+
+dir		= ./demoCA		# Where everything is kept
+certs		= $dir/certs		# Where the issued certs are kept
+crl_dir		= $dir/crl		# Where the issued crl are kept
+database	= $dir/index.txt	# database index file.
+#unique_subject	= no			# Set to 'no' to allow creation of
+					# several ctificates with same subject.
+new_certs_dir	= $dir/newcerts		# default place for new certs.
+
+certificate	= $dir/cacert.pem 	# The CA certificate
+serial		= $dir/serial 		# The current serial number
+crlnumber	= $dir/crlnumber	# the current crl number
+					# must be commented out to leave a V1 CRL
+crl		= $dir/crl.pem 		# The current CRL
+private_key	= $dir/private/cakey.pem# The private key
+RANDFILE	= $dir/private/.rand	# private random number file
+
+x509_extensions	= usr_cert		# The extentions to add to the cert
+
+# Comment out the following two lines for the "traditional"
+# (and highly broken) format.
+name_opt 	= ca_default		# Subject Name options
+cert_opt 	= ca_default		# Certificate field options
+
+# Extension copying option: use with caution.
+# copy_extensions = copy
+
+# Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
+# so this is commented out by default to leave a V1 CRL.
+# crlnumber must also be commented out to leave a V1 CRL.
+# crl_extensions	= crl_ext
+
+default_days	= 365			# how long to certify for
+default_crl_days= 30			# how long before next CRL
+default_md	= default		# use public key default MD
+preserve	= no			# keep passed DN ordering
+
+# A few difference way of specifying how similar the request should look
+# For type CA, the listed attributes must be the same, and the optional
+# and supplied fields are just that :-)
+policy		= policy_match
+
+# For the CA policy
+[ policy_match ]
+countryName		= match
+stateOrProvinceName	= match
+organizationName	= match
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+# For the 'anything' policy
+# At this point in time, you must list all acceptable 'object'
+# types.
+[ policy_anything ]
+countryName		= optional
+stateOrProvinceName	= optional
+localityName		= optional
+organizationName	= optional
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+####################################################################
+[ req ]
+default_bits		= 1024
+default_keyfile 	= privkey.pem
+distinguished_name	= req_distinguished_name
+attributes		= req_attributes
+x509_extensions	= v3_ca	# The extentions to add to the self signed cert
+
+# Passwords for private keys if not present they will be prompted for
+# input_password = secret
+# output_password = secret
+
+# This sets a mask for permitted string types. There are several options. 
+# default: PrintableString, T61String, BMPString.
+# pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
+# utf8only: only UTF8Strings (PKIX recommendation after 2004).
+# nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
+# MASK:XXXX a literal mask value.
+# WARNING: ancient versions of Netscape crash on BMPStrings or UTF8Strings.
+string_mask = utf8only
+
+req_extensions = v3_req # The extensions to add to a certificate request
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= US
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName_default	= California
+
+localityName			= Locality Name (eg, city)
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= KBase
+
+# we can do this but it is not needed normally :-)
+#1.organizationName		= Second Organization Name (eg, company)
+#1.organizationName_default	= World Wide Web Pty Ltd
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+#organizationalUnitName_default	=
+
+commonName			= Common Name (e.g. server FQDN or YOUR name)
+commonName_max			= 64
+commonName_default		= ${ENV::PUBLIC_ADDRESS}
+
+emailAddress			= Email Address
+emailAddress_max		= 64
+
+# SET-ex3			= SET extension number 3
+
+[ req_attributes ]
+challengePassword		= A challenge password
+challengePassword_min		= 4
+challengePassword_max		= 20
+
+unstructuredName		= An optional company name
+
+[ usr_cert ]
+
+# These extensions are added when 'ca' signs a request.
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# Here are some examples of the usage of nsCertType. If it is omitted
+# the certificate can be used for anything *except* object signing.
+
+# This is OK for an SSL server.
+# nsCertType			= server
+
+# For an object signing certificate this would be used.
+# nsCertType = objsign
+
+# For normal client use this is typical
+# nsCertType = client, email
+
+# and for everything including object signing:
+# nsCertType = client, email, objsign
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OpenSSL Generated Certificate"
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsBaseUrl
+#nsRevocationUrl
+#nsRenewalUrl
+#nsCaPolicyUrl
+#nsSslServerName
+
+# This is required for TSA certificates.
+# extendedKeyUsage = critical,timeStamping
+
+[ v3_req ]
+
+# Extensions to add to a certificate request
+
+basicConstraints = CA:TRUE
+keyUsage = digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = $ENV::PUBLIC_ADDRESS
+
+[ v3_ca ]
+
+
+# Extensions for a typical CA
+
+
+# PKIX recommendation.
+
+subjectKeyIdentifier=hash
+
+authorityKeyIdentifier=keyid:always,issuer
+
+# This is what PKIX recommends but some broken software chokes on critical
+# extensions.
+#basicConstraints = critical,CA:true
+# So we do this instead.
+basicConstraints = CA:true
+
+# Key usage: this is typical for a CA certificate. However since it will
+# prevent it being used as an test self-signed certificate it is best
+# left out by default.
+# keyUsage = cRLSign, keyCertSign
+
+# Some might want this also
+# nsCertType = sslCA, emailCA
+
+# Include email address in subject alt name: another PKIX recommendation
+# subjectAltName=email:copy
+# Copy issuer details
+# issuerAltName=issuer:copy
+
+# DER hex encoding of an extension: beware experts only!
+# obj=DER:02:03
+# Where 'obj' is a standard or added object
+# You can even override a supported extension:
+# basicConstraints= critical, DER:30:03:01:01:FF
+
+[ crl_ext ]
+
+# CRL extensions.
+# Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
+
+# issuerAltName=issuer:copy
+authorityKeyIdentifier=keyid:always
+
+[ proxy_cert_ext ]
+# These extensions should be added when creating a proxy certificate
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# Here are some examples of the usage of nsCertType. If it is omitted
+# the certificate can be used for anything *except* object signing.
+
+# This is OK for an SSL server.
+# nsCertType			= server
+
+# For an object signing certificate this would be used.
+# nsCertType = objsign
+
+# For normal client use this is typical
+# nsCertType = client, email
+
+# and for everything including object signing:
+# nsCertType = client, email, objsign
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OpenSSL Generated Certificate"
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsBaseUrl
+#nsRevocationUrl
+#nsRenewalUrl
+#nsCaPolicyUrl
+#nsSslServerName
+
+# This really needs to be in place for it to be a proxy certificate.
+proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,policy:foo
+
+####################################################################
+[ tsa ]
+
+default_tsa = tsa_config1	# the default TSA section
+
+[ tsa_config1 ]
+
+# These are used by the TSA reply generation only.
+dir		= ./demoCA		# TSA root directory
+serial		= $dir/tsaserial	# The current serial number (mandatory)
+crypto_device	= builtin		# OpenSSL engine to use for signing
+signer_cert	= $dir/tsacert.pem 	# The TSA signing certificate
+					# (optional)
+certs		= $dir/cacert.pem	# Certificate chain to include in reply
+					# (optional)
+signer_key	= $dir/private/tsakey.pem # The TSA private key (optional)
+
+default_policy	= tsa_policy1		# Policy if request did not specify it
+					# (optional)
+other_policies	= tsa_policy2, tsa_policy3	# acceptable policies (optional)
+digests		= md5, sha1		# Acceptable message digests (mandatory)
+accuracy	= secs:1, millisecs:500, microsecs:100	# (optional)
+clock_precision_digits  = 0	# number of digits after dot. (optional)
+ordering		= yes	# Is ordering defined for timestamps?
+				# (optional, default: no)
+tsa_name		= yes	# Must the TSA name be included in the reply?
+				# (optional, default: no)
+ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
+				# (optional, default: no)

--- a/src/java/us/kbase/templates/module_config_yaml.vm.properties
+++ b/src/java/us/kbase/templates/module_config_yaml.vm.properties
@@ -12,3 +12,4 @@ module-version:
 
 owners:
     [$user_name]
+

--- a/src/java/us/kbase/templates/module_dockerfile.vm.properties
+++ b/src/java/us/kbase/templates/module_dockerfile.vm.properties
@@ -1,19 +1,5 @@
-FROM kbase/depl:latest
+FROM kbase/sdkbase:latest
 MAINTAINER #if($username)${username}#{else}KBase Developer#{end}
-
-# Install the SDK (should go away eventually)
-RUN \
-  . /kb/dev_container/user-env.sh && \
-  cd /kb/dev_container/modules && \
-  rm -rf jars && \
-  git clone https://github.com/kbase/jars && \
-  rm -rf kb_sdk && \
-  git clone https://github.com/kbase/kb_sdk -b develop && \
-  cd /kb/dev_container/modules/jars && \
-  make deploy && \
-  cd /kb/dev_container/modules/kb_sdk && \
-  make
-
 
 # -----------------------------------------
 
@@ -36,7 +22,6 @@ RUN R -q -e 'if(!require(httr)) install.packages("httr", repos="http://cran.us.r
 
 COPY ./ /kb/module
 RUN mkdir -p /kb/module/work
-ENV PATH=$PATH:/kb/dev_container/modules/kb_sdk/bin
 
 WORKDIR /kb/module
 


### PR DESCRIPTION
This adds support to the SDK to build a base image for testing purposes.  It also changes the Dockerfile template to use kbase/sdkbase:latest instead of kbase/depl:latest.