### PR TITLE
Fix in Python client for invalid request headers

### DIFF
--- a/src/java/us/kbase/templates/python_client.vm.properties
+++ b/src/java/us/kbase/templates/python_client.vm.properties
@@ -32,7 +32,7 @@ def _get_token(user_id, password,
                         'grant_type=client_credentials'):
     # This is bandaid helper function until we get a full
     # KBase python auth client released
-    auth = _base64.encodestring(user_id + ':' + password)
+    auth = _base64.b64encode(user_id + ':' + password)
     headers = {'Authorization': 'Basic ' + auth}
     ret = _requests.get(auth_svc, headers=headers, allow_redirects=True)
     status = ret.status_code


### PR DESCRIPTION
We were using a base64 encoding that tacked a newline to the end of a string used in the client request headers.  This works fine in python 2.7.9, but fails in python 2.7.10+ throwing an error saying invalid header value from httplib.py.  Following the fix from https://github.com/abbyysdk/ocrsdk.com/commit/6d86c6e7ba86e6af4d5c52bb7eeca27cf78fde7e, this fixes the bug.