### PR TITLE
Fix python server error handling, don't hardcode JAVA_HOME

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -169,24 +169,18 @@ commit=${git.commit}</echo>
 
     <!-- Create main shell script-->
     <echo file="${bin.local}/${module_builder.sh.file}">#!/bin/bash
-export JAVA_HOME=${env.JAVA_HOME}
-export PATH=$JAVA_HOME/bin:$PATH
-$JAVA_HOME/bin/java -cp ${lib.classpath}:${jar.absolute.path} us.kbase.mobu.ModuleBuilder $@
+java -cp ${lib.classpath}:${jar.absolute.path} us.kbase.mobu.ModuleBuilder $@
     </echo>
     <chmod file="${bin.local}/${module_builder.sh.file}" perm="a+x"/>
     <!-- Create old main shell script-->
     <echo file="${bin.local}/${module_builder.sh.old.file}">#!/bin/bash
-export JAVA_HOME=${env.JAVA_HOME}
-export PATH=$JAVA_HOME/bin:$PATH
-$JAVA_HOME/bin/java -cp ${lib.classpath}:${jar.absolute.path} us.kbase.mobu.ModuleBuilder $@
+java -cp ${lib.classpath}:${jar.absolute.path} us.kbase.mobu.ModuleBuilder $@
     </echo>
     <chmod file="${bin.local}/${module_builder.sh.old.file}" perm="a+x"/>
     <echo>Successfully built: ${bin.local}/${module_builder.sh.file}</echo>
     <!-- Create ws-tools shell script-->
     <echo file="${bin.local}/${ws_tools.sh.file}">#!/bin/bash
-export JAVA_HOME=${env.JAVA_HOME}
-export PATH=$JAVA_HOME/bin:$PATH
-$JAVA_HOME/bin/java -cp ${lib.classpath}:${jar.absolute.path} us.kbase.tools.WorkspaceTools $@
+java -cp ${lib.classpath}:${jar.absolute.path} us.kbase.tools.WorkspaceTools $@
     </echo>
     <chmod file="${bin.local}/${ws_tools.sh.file}" perm="a+x"/>
 

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -195,7 +195,7 @@ class JSONRPCServiceCustom(JSONRPCService):
             # Exception was raised inside the method.
             newerr = ServerError()
             newerr.trace = traceback.format_exc()
-            newerr.data = e.__str__()
+            newerr.data = e.message
             raise newerr
         return result
 


### PR DESCRIPTION
Currently the server is dumping the `__str__` representation of any
exceptions thrown by a server method (which includes the entire
stacktrace in the case of ServerErrors thrown by SDK clients) into the
message field of the error, which is meant for a end user readable
message. There's no way to present a reasonable error message to a user
with the current behavior, and neither the perl nor java servers behave
in the same way - they both provide short messages. Fix to copy the
message field of the caught exception as intended.

Also get rid of the seemingly unnecessary and highly annoying memoizing
of the JAVA_HOME envvar in the scripts.