### PR TITLE
Fix SDK tests to run with no external dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "submodules/jars"]
 	path = submodules/jars
 	url = https://github.com/kbase/jars
+[submodule "submodules/auth"]
+	path = submodules/auth
+	url = https://github.com/kbase/auth

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ bin: jars-submodule-init
 submodule-init:
 	git submodule init
 	git submodule update
+	cp submodules_hacks/AuthConstants.pm submodules/auth/Bio-KBase-Auth/lib/Bio/KBase/
 
 jars-submodule-init:
 	git submodule update --init submodules/jars

--- a/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
+++ b/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
@@ -560,13 +560,13 @@ public class TypeGeneratorTest extends Assert {
 			    lines.add("export KB_JOB_SERVICE_URL=" + jobServiceUrl);
 			//JavaTypeGenerator.checkEnvVars(lines, "PYTHONPATH");
 			lines.addAll(Arrays.asList(
-			        "cd \"" + serverOutDir.getAbsolutePath() + "\"",
-			        "if [ ! -d biokbase ]; then",
-			        "  cp -r ../../../lib/biokbase ./",
-                    "  cp -r $KB_TOP/modules/auth/lib/biokbase ./",
-			        "fi",
-			        "python " + serverFile.getName() + " --host localhost --port " + portNum + 
-			            " >py_server.out 2>py_server.err & pid=$!",
+					"cd \"" + serverOutDir.getAbsolutePath() + "\"",
+					"if [ ! -d biokbase ]; then",
+					"  cp -r ../../../lib/biokbase ./",
+					"  cp -r ../../../submodules/auth/python-libs/biokbase ./",
+					"fi",
+					"python " + serverFile.getName() + " --host localhost --port " + portNum + 
+						" >py_server.out 2>py_server.err & pid=$!",
 					"echo $pid > " + pidFile.getName()
 					));
 			TextUtils.writeFileLines(lines, uwsgiFile);
@@ -638,11 +638,11 @@ public class TypeGeneratorTest extends Assert {
 			    lines.add("export KB_JOB_SERVICE_URL=" + jobServiceUrl);
 			//JavaTypeGenerator.checkEnvVars(lines, "PERL5LIB");
 			lines.addAll(Arrays.asList(
-                    "cd \"" + serverOutDir.getAbsolutePath() + "\"",
-                    "if [ ! -d Bio ]; then",
-                    "  cp -r ../../../lib/Bio ./",
-                    "  cp -r $KB_TOP/modules/auth/lib/Bio ./",
-                    "fi",
+					"cd \"" + serverOutDir.getAbsolutePath() + "\"",
+					"if [ ! -d Bio ]; then",
+					"  cp -r ../../../lib/Bio ./",
+					"  cp -r ../../../submodules/auth/Bio-KBase-Auth/lib/Bio ./",
+					"fi",
 					"plackup --listen :" + portNum + " service.psgi >perl_server.out 2>perl_server.err & pid=$!",
 					"echo $pid > " + pidFile.getAbsolutePath()
 					));

--- a/submodules_hacks/AuthConstants.pm
+++ b/submodules_hacks/AuthConstants.pm
@@ -1,0 +1,22 @@
+package Bio::KBase::AuthConstants;
+
+use constant        globus_token_url   => 'https://nexus.api.globusonline.org/goauth/token?grant_type=client_credentials';
+use constant        globus_profile_url   => 'https://nexus.api.globusonline.org/users';
+use constant	    trust_token_signers => split(/\s+/, 'https://nexus.api.globusonline.org/goauth/keys');
+use constant	    role_service_url => 'https://kbase.us/services/authorization/Roles';
+
+use base 'Exporter';
+our @EXPORT_OK = qw(globus_token_url globus_profile_url trust_token_signers role_service_url);
+our %EXPORT_TAGS = ( 
+		    globus => [ qw(globus_token_url globus_profile_url trust_token_signers) ],
+		    kbase  => [ qw(role_service_url) ],
+		   );
+{
+    my %seen;
+    
+    push @{$EXPORT_TAGS{all}},
+    grep {!$seen{$_}++} @{$EXPORT_TAGS{$_}} foreach keys %EXPORT_TAGS;
+}
+
+1;
+

--- a/test_scripts/python/test_client.py
+++ b/test_scripts/python/test_client.py
@@ -10,6 +10,7 @@ def getErrorMessage(error):
     return message
 
 def main(argv):
+    sys.path.append('./')
     tests_filepath = None
     endpoint = None
     user = None


### PR DESCRIPTION
- make auth a submodule
	- add hack for config file to makefile
- add current directory to python path in test_client.py
- copy auth files from the submodule instead of from the dev_container

Other things that could be done, but aren't critial at all:
move typecomp into submodules dir
make kbapi-common a submodule rather than keeping the files in the
kb_sdk repo