### PR TITLE
Fix for bad java link in deplbase

### DIFF
--- a/sdkbase/Dockerfile
+++ b/sdkbase/Dockerfile
@@ -3,6 +3,8 @@ FROM kbase/deplbase:latest
 # Update kb_sdk at build time
 ONBUILD RUN \
   . /kb/dev_container/user-env.sh && \
+  rm /kb/runtime/java && \
+  ln -s /usr/lib/jvm/java-7-oracle /kb/runtime/java && \
   cd /kb/dev_container/modules && \
   rm -rf jars && \
   git clone https://github.com/kbase/jars && \


### PR DESCRIPTION
/kb/runtime/java in deplbase is a dead link