### PR TITLE
Use real MethodContext object in tests

### DIFF
--- a/src/java/us/kbase/templates/module_test_python_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_python_client.vm.properties
@@ -9,6 +9,7 @@ from pprint import pprint
 
 from biokbase.workspace.client import Workspace as workspaceService
 from ${module_name}.${module_name}Impl import ${module_name}
+from ${module_name}.${module_name}Server import MethodContext
 
 
 class ${module_name}Test(unittest.TestCase):
@@ -16,9 +17,16 @@ class ${module_name}Test(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         token = environ.get('KB_AUTH_TOKEN', None)
-        cls.ctx = {'token': token, 'provenance': [{'service': '${module_name}',
-            'method': 'please_never_use_it_in_production', 'method_params': []}],
-            'authenticated': 1}
+        # WARNING: don't call any logging methods on the context object,
+        # it'll result in a NoneType error
+        cls.ctx = MethodContext(None)
+        cls.ctx.update({'token': cls.token,
+                        'provenance': [
+                            {'service': '${module_name}',
+                             'method': 'please_never_use_it_in_production',
+                             'method_params': []
+                             }],
+                        'authenticated': 1})
         config_file = environ.get('KB_DEPLOYMENT_CONFIG', None)
         cls.cfg = {}
         config = ConfigParser()


### PR DESCRIPTION
could probably flush it out more with a fake IP address and so on, but
doesn't seem necessary. Add it later if needed.