### PR TITLE
Small changes in building process of generated SDK repos (SDK-20).

### DIFF
--- a/src/java/us/kbase/templates/module_dockerfile.vm.properties
+++ b/src/java/us/kbase/templates/module_dockerfile.vm.properties
@@ -26,7 +26,7 @@ RUN chmod 777 /kb/module
 
 WORKDIR /kb/module
 
-RUN make
+RUN make all
 
 ENTRYPOINT [ "./scripts/entrypoint.sh" ]
 

--- a/src/java/us/kbase/templates/module_makefile.vm.properties
+++ b/src/java/us/kbase/templates/module_makefile.vm.properties
@@ -22,7 +22,9 @@ ANT = $(ANT_HOME)/bin/ant
 
 .PHONY: test
 
-default: compile build build-startup-script build-executable-script build-test-script
+default: compile
+
+all: compile build build-startup-script build-executable-script build-test-script
 
 compile:
 	kb-sdk compile $(SPEC_FILE) \
@@ -140,6 +142,7 @@ build-test-script:
 	chmod +x $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 
 test:
+	if [ ! -f /kb/module/work/token ]; then echo -e '\nOutside a docker container please run "kb-sdk test" rather than "make test"\n' && exit 1; fi
 	bash $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 
 clean:


### PR DESCRIPTION
- switching to "make" instead of "make compile" and to "make all" instead of "make"
- blocking "make test" outside of docker container