### PR TITLE
Update python clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /sdkbase/ssl
 
 /temp_test_callback/
+/classes/

--- a/src/java/us/kbase/common/executionengine/CallbackServer.java
+++ b/src/java/us/kbase/common/executionengine/CallbackServer.java
@@ -51,7 +51,6 @@ import us.kbase.workspace.SubAction;
 public abstract class CallbackServer extends JsonServerServlet {
     //TODO NJS_SDK move to common repo
     
-    //TODO identical (or close to it) to kb_sdk call back server.
     // should probably go in java_common or make a common repo for shared
     // NJSW & KB_SDK code, since they're tightly coupled
     private static final long serialVersionUID = 1L;

--- a/src/java/us/kbase/kidl/KbFuncdef.java
+++ b/src/java/us/kbase/kidl/KbFuncdef.java
@@ -12,7 +12,6 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import us.kbase.common.service.Tuple2;
-import us.kbase.mobu.compiler.JavaFuncParam;
 
 /**
  * Class represents function definition in spec-file.

--- a/src/java/us/kbase/kidl/KbModule.java
+++ b/src/java/us/kbase/kidl/KbModule.java
@@ -100,6 +100,7 @@ public class KbModule {
 							"[" + Map.class.getName() + "], it has type: " + item.getClass().getName());
 				}
 			} else {
+				@SuppressWarnings("rawtypes")
 				Map<?,?> compProps = (Map)item;
 				String compType = Utils.getPerlSimpleType(compProps);
 				if (compType.equals("Typedef")) {

--- a/src/java/us/kbase/mobu/ModuleBuilder.java
+++ b/src/java/us/kbase/mobu/ModuleBuilder.java
@@ -204,6 +204,12 @@ public class ModuleBuilder {
             return 1;
 		}
     	
+        if (a.clAsyncVer != null && a.dynservVer != null) {
+            showError("Bad arguments",
+                    "clasyncver and dynserver cannot both be specified");
+            return 1;
+        }
+    	
     	// Step 2: check or create the output directory
     	File outDir = a.outDir == null ? new File(".") : new File(a.outDir);
         try {
@@ -256,14 +262,15 @@ public class ModuleBuilder {
             }
         }
         try {
-			RunCompileCommand.generate(specFile, a.url, a.jsClientSide, a.jsClientName, a.perlClientSide, 
-			        a.perlClientName, a.perlServerSide, a.perlServerName, a.perlImplName, 
-			        a.perlPsgiName, a.perlEnableRetries, a.pyClientSide, a.pyClientName, 
-			        a.pyServerSide, a.pyServerName, a.pyImplName, a.javaClientSide, 
-			        a.javaServerSide, a.javaPackageParent, a.javaSrcDir, a.javaLibDir, 
-			        a.javaBuildXml, a.javaGwtPackage, a.rClientSide, a.rClientName, 
+            RunCompileCommand.generate(specFile, a.url, a.jsClientSide, a.jsClientName, a.perlClientSide, 
+                    a.perlClientName, a.perlServerSide, a.perlServerName, a.perlImplName, 
+                    a.perlPsgiName, a.perlEnableRetries, a.pyClientSide, a.pyClientName, 
+                    a.pyServerSide, a.pyServerName, a.pyImplName, a.javaClientSide, 
+                    a.javaServerSide, a.javaPackageParent, a.javaSrcDir, a.javaLibDir, 
+                    a.javaBuildXml, a.javaGwtPackage, a.rClientSide, a.rClientName, 
                     a.rServerSide, a.rServerName, a.rImplName, true, outDir, a.jsonSchema, 
-                    a.makefile, a.clAsyncVer, semanticVersion, gitUrl, gitCommitHash);
+                    a.makefile, a.clAsyncVer, a.dynservVer, semanticVersion,
+                    gitUrl, gitCommitHash);
 		} catch (Throwable e) {
 			System.err.println("Error compiling KIDL specfication:");
 			System.err.println(e.getMessage());
@@ -541,6 +548,14 @@ public class ModuleBuilder {
         @Parameter(names="--clasyncver",description="Will set in client code version of service for asyncronous calls " +
         		"(it could be git commit hash of version registered in catalog or one of version tags: dev/beta/release)")
         String clAsyncVer = null;
+        
+        @Parameter(names="--dynservver", description="Clients will be built " +
+                "for use with KBase dynamic services (e.g. with URL lookup " +
+                "via the Service Wizard) with the specified version " +
+                "(git commit hash or dev/beta/release)." +
+                "clasyncver may not be specified if " +
+                "dynservver is specified.")
+        String dynservVer = null;
 
         @Parameter(required=true, description="<KIDL spec file>")
         List <String> specFileNames;

--- a/src/java/us/kbase/mobu/compiler/RunCompileCommand.java
+++ b/src/java/us/kbase/mobu/compiler/RunCompileCommand.java
@@ -9,7 +9,6 @@ import java.io.Reader;
 import java.io.Writer;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -41,8 +40,9 @@ public class RunCompileCommand {
             boolean withJavaBuildXml, String javaGwtPackage, boolean rClientSide, 
             String rClientName, boolean rServerSide, String rServerName, 
             String rImplName, boolean newStyle, File outDir, String jsonSchemaPath, 
-            boolean createMakefile, String clientAsyncVer, String semanticVersion, 
-            String gitUrl, String gitCommitHash) throws Exception {
+            boolean createMakefile, String clientAsyncVer, String dynserv,
+            String semanticVersion, String gitUrl, String gitCommitHash)
+            throws Exception {
     	
         FileSaver javaSrcDir = null;
         if (javaSrcPath != null)
@@ -139,18 +139,20 @@ public class RunCompileCommand {
         if (javaGwtPackage != null)
             javaClientSide = true;
         JavaData javaParsingData = null;
-        if (javaClientSide)
+        if (javaClientSide) {
+            //TODO DYNSERV add dynamic service client generation to all clients except Python
             javaParsingData = JavaTypeGenerator.processSpec(services, javaSrcDir, 
                     javaPackageParent, javaServerSide, javaLibDir, javaGwtPackage, 
                     url == null ? null : new URL(url), javaBuildXml, javaMakefile,
                     clientAsyncVer, semanticVersion, gitUrl, gitCommitHash);
+        }
         TemplateBasedGenerator.generate(services, url, jsClientSide, jsClientName, 
                 perlClientSide, perlClientName, perlServerSide, perlServerName, 
                 perlImplName, perlPsgiName, pyClientSide, pyClientName, 
                 pyServerSide, pyServerName, pyImplName, rClientSide, rClientName, 
                 rServerSide, rServerName, rImplName, perlEnableRetries, newStyle, 
                 ip, output, perlMakefile, pyMakefile, newStyle, clientAsyncVer,
-                semanticVersion, gitUrl, gitCommitHash);
+                dynserv, semanticVersion, gitUrl, gitCommitHash);
         String reportFile = System.getenv("KB_SDK_COMPILE_REPORT_FILE");
         if (reportFile == null || reportFile.isEmpty())
             reportFile = System.getProperty("KB_SDK_COMPILE_REPORT_FILE");

--- a/src/java/us/kbase/mobu/compiler/TemplateBasedGenerator.java
+++ b/src/java/us/kbase/mobu/compiler/TemplateBasedGenerator.java
@@ -32,7 +32,8 @@ public class TemplateBasedGenerator {
         generate(srvs, defaultUrl, genJs, jsClientName, genPerl, perlClientName, genPerlServer, 
                 perlServerName, perlImplName, perlPsgiName, genPython, pythonClientName, 
                 genPythonServer, pythonServerName, pythonImplName, false, null, false, null, null, 
-                enableRetries, newStyle, ip, output, null, null, false, null, null, null, null);
+                enableRetries, newStyle, ip, output, null, null, false, null,
+                null, null, null, null);
     }
     
     public static boolean genPerlServer(boolean genPerlServer, 
@@ -59,14 +60,14 @@ public class TemplateBasedGenerator {
             String rClientName, boolean genRServer, String rServerName, String rImplName, 
             boolean enableRetries, boolean newStyle, IncludeProvider ip, FileSaver output,
             FileSaver perlMakefile, FileSaver pyMakefile, boolean asyncByDefault,
-            String clientAsyncVer, String semanticVersion, String gitUrl,
-            String gitCommitHash) throws Exception {
+            String clientAsyncVer, String dynservVer, String semanticVersion,
+            String gitUrl, String gitCommitHash) throws Exception {
         generate(srvs, defaultUrl, genJs, jsClientName, genPerl, perlClientName, 
                 genPerlServer, perlServerName, perlImplName, perlPsgiName, genPython, 
                 pythonClientName, genPythonServer, pythonServerName, pythonImplName, 
                 genR, rClientName, genRServer, rServerName, rImplName, enableRetries, 
                 newStyle, ip, output, perlMakefile, pyMakefile, asyncByDefault, 
-                clientAsyncVer, semanticVersion, gitUrl, gitCommitHash, null);
+                clientAsyncVer, dynservVer, semanticVersion, gitUrl, gitCommitHash, null);
     }
     
     @SuppressWarnings("unchecked")
@@ -79,8 +80,9 @@ public class TemplateBasedGenerator {
             String rClientName, boolean genRServer, String rServerName, String rImplName, 
             boolean enableRetries, boolean newStyle, IncludeProvider ip, FileSaver output,
             FileSaver perlMakefile, FileSaver pyMakefile, boolean asyncByDefault,
-            String clientAsyncVer, String semanticVersion, String gitUrl,
-            String gitCommitHash, Map<String, String> prevCode) throws Exception {
+            String clientAsyncVer, String dynservVer, String semanticVersion,
+            String gitUrl, String gitCommitHash, Map<String, String> prevCode)
+            throws Exception {
         if (semanticVersion == null)
             semanticVersion = "";
         if (gitUrl == null)
@@ -127,6 +129,16 @@ public class TemplateBasedGenerator {
         context.put("empty_escaper", "");  // ${empty_escaper}
         context.put("display", new StringUtils());
         context.put("async_version", clientAsyncVer);
+        context.put("dynserv_ver", dynservVer);
+        final String serviceVer;
+        if (clientAsyncVer != null) {
+            serviceVer = clientAsyncVer;
+        } else if (dynservVer != null) {
+            serviceVer = dynservVer;
+        } else {
+            serviceVer = null;
+        }
+        context.put("service_ver", serviceVer);
         if (jsClientName != null) {
             Writer jsClient = output.openWriter(jsClientName + ".js");
             TemplateFormatter.formatTemplate("javascript_client", context, newStyle, jsClient);
@@ -170,7 +182,8 @@ public class TemplateBasedGenerator {
                     continue;
                 for (int methodPos = 0; methodPos < methods.size(); methodPos++) {
                     Map<String, Object> method = methods.get(methodPos);
-                    Boolean async = (Boolean)method.get("async");
+                    //TODO ROMAN should async go into the map or can this line be deleted?
+//                    Boolean async = (Boolean)method.get("async");
                     method.put("async", true);
                     //if (async == null || !async)
                     //    method.put("could_be_sync", true);

--- a/src/java/us/kbase/mobu/renamer/ModuleRenamer.java
+++ b/src/java/us/kbase/mobu/renamer/ModuleRenamer.java
@@ -216,7 +216,7 @@ public class ModuleRenamer {
                     false, perlClientName, genPerlServer, perlServerName, perlImplName, perlPsgiName, 
                     false, pythonClientName, genPythonServer, pythonServerName, pythonImplName, 
                     false, rClientName, genRServer, rServerName, rImplName, false, true, ip, 
-                    srcOut, null, null, false, null, null, 
+                    srcOut, null, null, false, null, null, null, 
                     null, null, prevCode);
         }
         for (String key : generatedFiles.keySet()) {

--- a/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
+++ b/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
@@ -722,13 +722,13 @@ public class TypeGeneratorTest extends Assert {
                 true, null, true, null, null, "service.psgi", false, true, 
                 null, true, null, null, false, false, null, null, null, false, 
                 null, false, null, false, null, null, newStyle, serverOutDir, 
-                null, true, null, null, null, null);
+                null, true, null, null, null, null, null);
         // Generate clients (always new style)
         RunCompileCommand.generate(testFile, null, true, null, 
                 true, null, false, null, null, null, false, true, 
                 null, false, null, null, false, false, null, null, null, false, 
                 null, false, null, false, null, null, true, serverOutDir, null, 
-                true, null, null, null, null);
+                true, null, null, null, null, null);
         return serverOutDir;
 	}
 

--- a/src/java/us/kbase/templates/python_client.vm.properties
+++ b/src/java/us/kbase/templates/python_client.vm.properties
@@ -102,9 +102,9 @@ class ${module.module_name}(object):
             self, url=None, timeout=30 * 60, user_id=None,
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
-            auth_svc='https://kbase.us/services/authorization/Sessions/Login'#if($any_async || $async_version),
-            async_job_check_time_ms=5000,
-            async_version=#if($async_version)'$async_version'#{else}None#{end}#{end}):
+            auth_svc='https://kbase.us/services/authorization/Sessions/Login'#if($any_async || $async_version || $dynserv_ver),
+            service_ver=#if($service_ver)'$service_ver'#{else}None#{end}#if($any_async || $async_version),
+            async_job_check_time_ms=5000#{end}#{end}):
         if url is None:
 #if( $default_service_url )
             url = '${default_service_url}'
@@ -120,7 +120,9 @@ class ${module.module_name}(object):
         self.trust_all_ssl_certificates = trust_all_ssl_certificates
 #if( $any_async || $async_version)
         self.async_job_check_time = async_job_check_time_ms / 1000.0
-        self.async_version = async_version
+#end
+#if($any_async || $async_version || $dynserv_ver)
+        self.service_ver = service_ver
 #end
         # token overrides user_id and password
         if token is not None:
@@ -142,7 +144,7 @@ class ${module.module_name}(object):
         if self.timeout < 1:
             raise ValueError('Timeout value must be at least 1 second')
 
-    def _call(self, method, params, context=None):
+    def _call(self, url, method, params, context=None):
         arg_hash = {'method': method,
                     'params': params,
                     'version': '1.1',
@@ -154,7 +156,7 @@ class ${module.module_name}(object):
             arg_hash['context'] = context
 
         body = _json.dumps(arg_hash, cls=_JSONObjectEncoder)
-        ret = _requests.post(self.url, data=body, headers=self._headers,
+        ret = _requests.post(url, data=body, headers=self._headers,
                              timeout=self.timeout,
                              verify=not self.trust_all_ssl_certificates)
         ret.encoding = 'utf-8'
@@ -177,21 +179,27 @@ class ${module.module_name}(object):
         if len(resp['result']) == 1:
             return resp['result'][0]
         return resp['result']
+
+    def _get_dynamic_service_url(self, service, service_version):
+        service_status_ret = self._call(
+            self.url, 'ServiceWizard.get_service_status',
+            [{'module_name': service, 'version': service_version}])
+        return service_status_ret['url']
 #if($any_async || $async_version)
 
     def _check_job(self, job_id):
-        return self._call('${module.module_name}._check_job', [job_id])
+        return self._call(self.url, '${module.module_name}._check_job', [job_id])
 #end
 #foreach($method in $module.methods)
 #set($comma_args = "#if($method.arg_count>0), ${method.args}#{else}#{end}")
 #if($method.async || $async_version)
 
     def _${method.name}_submit(self${comma_args}, context=None):
-        if self.async_version:
+        if self.service_ver:
             if not context:
                 context = {}
-            context['service_ver'] = self.async_version
-        return self._call('${module.module_name}._${method.name}_submit',
+            context['service_ver'] = self.service_ver
+        return self._call(self.url, '${module.module_name}._${method.name}_submit',
                           [${method.args}], context)
 
     def ${method.name}(self${comma_args}, context=None):
@@ -224,7 +232,12 @@ class ${module.module_name}(object):
 #end
         """
 #end
-        return self._call('${module.module_name}.${method.name}',
+#if($dynserv_ver)
+        url = self._get_dynamic_service_url('${module.module_name}', self.service_ver)
+#else
+        url = self.url
+#end
+        return self._call(url, '${module.module_name}.${method.name}',
                           [${method.args}], context)
 #end## of if-async
 #end

--- a/src/java/us/kbase/templates/python_client.vm.properties
+++ b/src/java/us/kbase/templates/python_client.vm.properties
@@ -15,7 +15,6 @@ except ImportError:
 import requests as _requests
 import urlparse as _urlparse
 import random as _random
-import base64 as _base64
 from ConfigParser import ConfigParser as _ConfigParser
 import os as _os
 #if( $any_async || $async_version )
@@ -27,14 +26,15 @@ _AJ = 'application/json'
 _URL_SCHEME = frozenset(['http', 'https'])
 
 
-def _get_token(user_id, password,
-               auth_svc='https://nexus.api.globusonline.org/goauth/token?' +
-                        'grant_type=client_credentials'):
+def _get_token(user_id, password, auth_svc):
     # This is bandaid helper function until we get a full
     # KBase python auth client released
-    auth = _base64.b64encode(user_id + ':' + password)
-    headers = {'Authorization': 'Basic ' + auth}
-    ret = _requests.get(auth_svc, headers=headers, allow_redirects=True)
+    # note that currently globus usernames, and therefore kbase usernames,
+    # cannot contain non-ascii characters. In python 2, quote doesn't handle
+    # unicode, so if this changes this client will need to change.
+    body = ('user_id=' + _requests.utils.quote(user_id) + '&password=' +
+            _requests.utils.quote(password) + '&fields=token')
+    ret = _requests.post(auth_svc, data=body, allow_redirects=True)
     status = ret.status_code
     if status >= 200 and status <= 299:
         tok = _json.loads(ret.text)
@@ -43,7 +43,7 @@ def _get_token(user_id, password,
                         'combination for user %s' % (user_id))
     else:
         raise Exception(ret.text)
-    return tok['access_token']
+    return tok['token']
 
 
 def _read_inifile(file=_os.environ.get(  # @ReservedAssignment
@@ -94,11 +94,13 @@ class _JSONObjectEncoder(_json.JSONEncoder):
 
 class ${module.module_name}(object):
 
-    def __init__(self, url=None, timeout=30 * 60, user_id=None,
-                 password=None, token=None, ignore_authrc=False,
-                 trust_all_ssl_certificates=False#if($any_async || $async_version),
-                 async_job_check_time_ms=5000,
-                 async_version=#if($async_version)'$async_version'#{else}None#{end}#{end}):
+    def __init__(
+            self, url=None, timeout=30 * 60, user_id=None,
+            password=None, token=None, ignore_authrc=False,
+            trust_all_ssl_certificates=False,
+            auth_svc='https://kbase.us/services/authorization/Sessions/Login'#if($any_async || $async_version),
+            async_job_check_time_ms=5000,
+            async_version=#if($async_version)'$async_version'#{else}None#{end}#{end}):
         if url is None:
 #if( $default_service_url )
             url = '${default_service_url}'
@@ -120,7 +122,8 @@ class ${module.module_name}(object):
         if token is not None:
             self._headers['AUTHORIZATION'] = token
         elif user_id is not None and password is not None:
-            self._headers['AUTHORIZATION'] = _get_token(user_id, password)
+            self._headers['AUTHORIZATION'] = _get_token(
+                user_id, password, auth_svc)
         elif 'KB_AUTH_TOKEN' in _os.environ:
             self._headers['AUTHORIZATION'] = _os.environ.get('KB_AUTH_TOKEN')
         elif not ignore_authrc:
@@ -131,7 +134,7 @@ class ${module.module_name}(object):
                 elif(authdata.get('user_id') is not None and
                         authdata.get('password') is not None):
                     self._headers['AUTHORIZATION'] = _get_token(
-                        authdata['user_id'], authdata['password'])
+                        authdata['user_id'], authdata['password'], auth_svc)
         if self.timeout < 1:
             raise ValueError('Timeout value must be at least 1 second')
 

--- a/src/java/us/kbase/templates/python_client.vm.properties
+++ b/src/java/us/kbase/templates/python_client.vm.properties
@@ -5,18 +5,22 @@
 #
 #[[############################################################]]#
 
-try:
-    import json as _json
-except ImportError:
-    import sys
-    sys.path.append('simplejson-2.3.3')
-    import simplejson as _json
+from __future__ import print_function
 
+import json as _json
 import requests as _requests
-import urlparse as _urlparse
 import random as _random
-from ConfigParser import ConfigParser as _ConfigParser
 import os as _os
+
+try:
+    from configparser import ConfigParser as _ConfigParser  # py 3
+except ImportError:
+    from ConfigParser import ConfigParser as _ConfigParser  # py 2
+
+try:
+    from urllib.parse import urlparse as _urlparse  # py3
+except ImportError:
+    from urlparse import urlparse as _urlparse  # py2
 #if( $any_async || $async_version )
 import time
 #end
@@ -61,8 +65,8 @@ def _read_inifile(file=_os.environ.get(  # @ReservedAssignment
                         else None for x in ('user_id', 'token',
                                             'client_secret', 'keyfile',
                                             'keyfile_passphrase', 'password')}
-        except Exception, e:
-            print "Error while reading INI file %s: %s" % (file, e)
+        except Exception as e:
+            print('Error while reading INI file {}: {}'.format(file, e))
     return authdata
 
 
@@ -107,7 +111,7 @@ class ${module.module_name}(object):
 #else
             raise ValueError('A url is required')
 #end
-        scheme, _, _, _, _, _ = _urlparse.urlparse(url)
+        scheme, _, _, _, _, _ = _urlparse(url)
         if scheme not in _URL_SCHEME:
             raise ValueError(url + " isn't a valid http url")
         self.url = url

--- a/src/java/us/kbase/templates/python_client.vm.properties
+++ b/src/java/us/kbase/templates/python_client.vm.properties
@@ -46,22 +46,6 @@ def _get_token(user_id, password,
     return tok['access_token']
 
 
-def _read_rcfile(file=_os.environ['HOME'] + '/.authrc'):  # @ReservedAssignment
-    # Another bandaid to read in the ~/.authrc file if one is present
-    authdata = None
-    if _os.path.exists(file):
-        try:
-            with open(file) as authrc:
-                rawdata = _json.load(authrc)
-                # strip down whatever we read to only what is legit
-                authdata = {x: rawdata.get(x) for x in (
-                    'user_id', 'token', 'client_secret', 'keyfile',
-                    'keyfile_passphrase', 'password')}
-        except Exception, e:
-            print "Error while reading authrc file %s: %s" % (file, e)
-    return authdata
-
-
 def _read_inifile(file=_os.environ.get(  # @ReservedAssignment
                   'KB_DEPLOYMENT_CONFIG', _os.environ['HOME'] +
                   '/.kbase_config')):
@@ -85,6 +69,7 @@ def _read_inifile(file=_os.environ.get(  # @ReservedAssignment
 class ServerError(Exception):
 
     def __init__(self, name, code, message, data=None, error=None):
+        super(Exception, self).__init__(message)
         self.name = name
         self.code = code
         self.message = '' if message is None else message
@@ -112,7 +97,8 @@ class ${module.module_name}(object):
     def __init__(self, url=None, timeout=30 * 60, user_id=None,
                  password=None, token=None, ignore_authrc=False,
                  trust_all_ssl_certificates=False#if($any_async || $async_version),
-                 async_job_check_time_ms=5000,async_version=#if($async_version)'$async_version'#{else}None#{end}#{end}):
+                 async_job_check_time_ms=5000,
+                 async_version=#if($async_version)'$async_version'#{else}None#{end}#{end}):
         if url is None:
 #if( $default_service_url )
             url = '${default_service_url}'
@@ -139,72 +125,69 @@ class ${module.module_name}(object):
             self._headers['AUTHORIZATION'] = _os.environ.get('KB_AUTH_TOKEN')
         elif not ignore_authrc:
             authdata = _read_inifile()
-            if authdata is None:
-                authdata = _read_rcfile()
             if authdata is not None:
                 if authdata.get('token') is not None:
                     self._headers['AUTHORIZATION'] = authdata['token']
-                elif(authdata.get('user_id') is not None
-                     and authdata.get('password') is not None):
+                elif(authdata.get('user_id') is not None and
+                        authdata.get('password') is not None):
                     self._headers['AUTHORIZATION'] = _get_token(
                         authdata['user_id'], authdata['password'])
         if self.timeout < 1:
             raise ValueError('Timeout value must be at least 1 second')
 
-    def _call(self, method, params, json_rpc_context = None):
+    def _call(self, method, params, context=None):
         arg_hash = {'method': method,
                     'params': params,
                     'version': '1.1',
                     'id': str(_random.random())[2:]
                     }
-        if json_rpc_context:
-            arg_hash['context'] = json_rpc_context
+        if context:
+            if type(context) is not dict:
+                raise ValueError('context is not type dict as required.')
+            arg_hash['context'] = context
 
         body = _json.dumps(arg_hash, cls=_JSONObjectEncoder)
         ret = _requests.post(self.url, data=body, headers=self._headers,
                              timeout=self.timeout,
                              verify=not self.trust_all_ssl_certificates)
-        if ret.status_code == _requests.codes.server_error:
-            json_header = None
-            if _CT in ret.headers:
-                json_header = ret.headers[_CT]
+        ret.encoding = 'utf-8'
+        if ret.status_code == 500:
             if _CT in ret.headers and ret.headers[_CT] == _AJ:
-                err = _json.loads(ret.text)
+                err = ret.json()
                 if 'error' in err:
                     raise ServerError(**err['error'])
                 else:
                     raise ServerError('Unknown', 0, ret.text)
             else:
                 raise ServerError('Unknown', 0, ret.text)
-        if ret.status_code != _requests.codes.OK:
+        if not ret.ok:
             ret.raise_for_status()
-        ret.encoding = 'utf-8'
-        resp = _json.loads(ret.text)
+        resp = ret.json()
         if 'result' not in resp:
             raise ServerError('Unknown', 0, 'An unknown server error occurred')
+        if not resp['result']:
+            return
+        if len(resp['result']) == 1:
+            return resp['result'][0]
         return resp['result']
-#if( $any_async || $async_version)
-        
+#if($any_async || $async_version)
+
     def _check_job(self, job_id):
-        resp = self._call('${module.module_name}._check_job', [job_id])
-        return resp[0]
+        return self._call('${module.module_name}._check_job', [job_id])
 #end
-        
-#foreach( $method in $module.methods )
-#set( $comma_args = "#if($method.arg_count>0), ${method.args}#{else}#{end}" )
-#if( $method.async || $async_version)
+#foreach($method in $module.methods)
+#set($comma_args = "#if($method.arg_count>0), ${method.args}#{else}#{end}")
+#if($method.async || $async_version)
 
-    def _${method.name}_submit(self${comma_args}, json_rpc_context = None):
-        if json_rpc_context and type(json_rpc_context) is not dict:
-            raise ValueError('Method ${method.name}: argument json_rpc_context is not type dict as required.')
+    def _${method.name}_submit(self${comma_args}, context=None):
         if self.async_version:
-            if not json_rpc_context:
-                json_rpc_context = {}
-            json_rpc_context['service_ver'] = self.async_version
+            if not context:
+                context = {}
+            context['service_ver'] = self.async_version
         return self._call('${module.module_name}._${method.name}_submit',
-                          [${method.args}], json_rpc_context)[0]
+                          [${method.args}], context)
 
-    def ${method.name}(self${comma_args}, json_rpc_context = None):
+    def ${method.name}(self${comma_args}, context=None):
 #if( $method.py_doc_lines.size() > 0 )
         """
 #foreach( $docline in $method.py_doc_lines )
@@ -212,7 +195,7 @@ class ${module.module_name}(object):
 #end
         """
 #end
-        job_id = self._${method.name}_submit(${method.args}#if($method.arg_count>0), #{end}json_rpc_context)
+        job_id = self._${method.name}_submit(${method.args}#if($method.arg_count>0), #{end}context)
         while True:
             time.sleep(self.async_job_check_time)
             job_state = self._check_job(job_id)
@@ -224,9 +207,9 @@ class ${module.module_name}(object):
 #else
                 return
 #end
-#else ## of if-async
+#else## of if-async
 
-    def ${method.name}(self${comma_args}, json_rpc_context = None):
+    def ${method.name}(self${comma_args}, context=None):
 #if( $method.py_doc_lines.size() > 0 )
         """
 #foreach( $docline in $method.py_doc_lines )
@@ -234,20 +217,8 @@ class ${module.module_name}(object):
 #end
         """
 #end
-        if json_rpc_context and type(json_rpc_context) is not dict:
-            raise ValueError('Method ${method.name}: argument json_rpc_context is not type dict as required.')
-#if( $method.ret_count == 1 )
-        resp = self._call('${module.module_name}.${method.name}',
-                          [${method.args}], json_rpc_context)
-        return resp[0]
-#elseif( $method.ret_count > 1 )
-        resp = self._call('${module.module_name}.${method.name}',
-                          [${method.args}], json_rpc_context)
-        return resp
-#else
-        self._call('${module.module_name}.${method.name}',
-                   [${method.args}], json_rpc_context)
-#end
-#end ## of if-async
+        return self._call('${module.module_name}.${method.name}',
+                          [${method.args}], context)
+#end## of if-async
 #end
 #end

--- a/test_scripts/python/test_client.py
+++ b/test_scripts/python/test_client.py
@@ -58,7 +58,7 @@ def main(argv):
         ret = None
         error = None
         try:
-            ret = method_instance(*params)
+            ret = method_instance(*params, context={})
         except Exception as ex:
             error = ex
         if expected_status == 'pass' or expected_status == 'nomatch':


### PR DESCRIPTION
* New compile flag --dynservver, similar to but exclusive to --clasyncver, causes clients to be compiled with url lookup via the Service Wizard
* No longer reads credentials from .authrc, only from .kbase_config
* py3 compatible
* passes pep8
* gets authentication token from the kbase auth service instead of Globus

TODO:
* Port changes to other clients
* Add pep8 test? probably not necessary
* Test for py3 compatibility. This is a big job; do it when servers are also py3 compatible. Probably needs tests running in a docker container, but this risks adding dependencies accidentally.
* Test with dynamic services. Getting this running will be a nightmare. Also probably requires a pre-configured docker container.