### PR TITLE
Changes in async call processing from clients in all languages.

### DIFF
--- a/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
+++ b/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
@@ -339,7 +339,7 @@ public class DockerClientServerTester {
                 "casperjs test " + new File("test_scripts/js/test-client.js").getAbsolutePath() + " "
                         + "--jq=" + new File("test_scripts/js/jquery-1.10.2.min.js").getAbsolutePath() + " "
                         + "--tests=" + configFile.getAbsolutePath() + 
-                        " --endpoint=" + clientEndpointUrl + " --token=" + token
+                        " --endpoint=" + clientEndpointUrl + " --token=\"" + token + "\""
                 ));
         TextUtils.writeFileLines(lines, shellFile);
         {

--- a/src/java/us/kbase/mobu/initializer/test/ExecEngineMock.java
+++ b/src/java/us/kbase/mobu/initializer/test/ExecEngineMock.java
@@ -58,6 +58,8 @@ public class ExecEngineMock extends JsonServerServlet {
     private Map<String, FinishJobParams> jobToResults = new LinkedHashMap<String, FinishJobParams>();
     private Map<String, String> moduleToDockerImage = new LinkedHashMap<String, String>();
     private Map<String, File> moduleToRepoDir = new LinkedHashMap<String, File>();
+    private static boolean debugCheckJobTimes = false;
+    private Long lastCheckJobAccessTime = null;
     
     public ExecEngineMock withModule(String moduleName, String dockerImage, File repoDir) {
         moduleToDockerImage.put(moduleName, dockerImage);
@@ -341,6 +343,10 @@ public class ExecEngineMock extends JsonServerServlet {
     public JobState checkJob(String jobId, AuthToken authPart, us.kbase.common.service.RpcContext... jsonRpcCallContext) throws Exception {
         JobState returnVal = null;
         //BEGIN check_job
+        if (lastCheckJobAccessTime != null && debugCheckJobTimes) {
+            System.out.println("ExecEngineMock.checkJob: time = " + (System.currentTimeMillis() - lastCheckJobAccessTime));
+        }
+        lastCheckJobAccessTime = System.currentTimeMillis();
         returnVal = new JobState();
         FinishJobParams result = jobToResults.get(jobId);
         if (result == null) {

--- a/src/java/us/kbase/templates/javascript_client.vm.properties
+++ b/src/java/us/kbase/templates/javascript_client.vm.properties
@@ -12,7 +12,9 @@ function ${module.module_name}(url, auth, auth_cb, timeout, async_job_check_time
     
     this.async_job_check_time_ms = async_job_check_time_ms;
     if (!this.async_job_check_time_ms)
-        this.async_job_check_time_ms = 5000;
+        this.async_job_check_time_ms = 100;
+    this.async_job_check_time_scale_percent = 150;
+    this.async_job_check_max_time_ms = 300000;  // 5 minutes
     this.service_version = service_version;
 #if( $service_ver )
     if (!this.service_version)
@@ -54,6 +56,7 @@ function ${module.module_name}(url, auth, auth_cb, timeout, async_job_check_time
                 json_rpc_context = {};
             json_rpc_context['service_ver'] = self.service_version;
         }
+        var async_job_check_time_ms = self.async_job_check_time_ms;
         self._${method.name}_submit(#if($method.arg_count==0)#{else}${method.args}, #{end}function(job_id) {
             var _checkCallback = null;
             _checkCallback = function(job_state) {
@@ -67,8 +70,12 @@ function ${module.module_name}(url, auth, auth_cb, timeout, async_job_check_time
 #end                    
                 } else {
                     setTimeout(function () {
+                        async_job_check_time_ms = async_job_check_time_ms * 
+                            self.async_job_check_time_scale_percent / 100;
+                        if (async_job_check_time_ms > self.async_job_check_max_time_ms)
+                            async_job_check_time_ms = self.async_job_check_max_time_ms;
                         self._check_job(job_id, _checkCallback, _errorCallback);
-                    }, self.async_job_check_time_ms);
+                    }, async_job_check_time_ms);
                 }
             };       
             _checkCallback({finished: 0});
@@ -140,6 +147,7 @@ function ${module.module_name}(url, auth, auth_cb, timeout, async_job_check_time
             throw 'Argument _callback must be a function if defined';
         if (_errorCallback && typeof _errorCallback !== 'function')
             throw 'Argument _errorCallback must be a function if defined';
+        var async_job_check_time_ms = self.async_job_check_time_ms;
         json_call_ajax(_url, "${module.module_name}._status_submit", 
             [], 1, function(job_id) {
             var _checkCallback = null;
@@ -150,8 +158,12 @@ function ${module.module_name}(url, auth, auth_cb, timeout, async_job_check_time
                     _callback(job_state.result[0]);
                 } else {
                     setTimeout(function () {
+                        async_job_check_time_ms = async_job_check_time_ms *
+                            self.async_job_check_time_scale_percent / 100;
+                        if (async_job_check_time_ms > self.async_job_check_max_time_ms)
+                            async_job_check_time_ms = self.async_job_check_max_time_ms;
                         self._check_job(job_id, _checkCallback, _errorCallback);
-                    }, self.async_job_check_time_ms);
+                    }, async_job_check_time_ms);
                 }
             };       
             _checkCallback({finished: 0});

--- a/src/java/us/kbase/templates/perl_client.vm.properties
+++ b/src/java/us/kbase/templates/perl_client.vm.properties
@@ -56,11 +56,18 @@ sub new
     };
 #if( $any_async || $async_version )
     my %arg_hash = @args;
-    my $async_job_check_time = 5.0;
+    $self->{async_job_check_time} = 0.1;
     if (exists $arg_hash{"async_job_check_time_ms"}) {
-        $async_job_check_time = $arg_hash{"async_job_check_time_ms"} / 1000.0;
+        $self->{async_job_check_time} = $arg_hash{"async_job_check_time_ms"} / 1000.0;
     }
-    $self->{async_job_check_time} = $async_job_check_time;
+    $self->{async_job_check_time_scale_percent} = 150;
+    if (exists $arg_hash{"async_job_check_time_scale_percent"}) {
+        $self->{async_job_check_time_scale_percent} = $arg_hash{"async_job_check_time_scale_percent"};
+    }
+    $self->{async_job_check_max_time} = 300;  # 5 minutes
+    if (exists $arg_hash{"async_job_check_max_time_ms"}) {
+        $self->{async_job_check_max_time} = $arg_hash{"async_job_check_max_time_ms"} / 1000.0;
+    }
     my $service_version = #if($service_ver)'$service_ver'#{else}undef#{end};
     if (exists $arg_hash{"service_version"}) {
         $service_version = $arg_hash{"async_version"};
@@ -227,8 +234,13 @@ sub ${method.name}
 {
     my($self, @args) = @_;
     my $job_id = $self->_${method.name}_submit(@args);
+    my $async_job_check_time = $self->{async_job_check_time};
     while (1) {
-        Time::HiRes::sleep($self->{async_job_check_time});
+        Time::HiRes::sleep($async_job_check_time);
+        $async_job_check_time *= $self->{async_job_check_time_scale_percent} / 100.0;
+        if ($async_job_check_time > $self->{async_job_check_max_time}) {
+            $async_job_check_time = $self->{async_job_check_max_time};
+        }
         my $job_state_ref = $self->_check_job($job_id);
         if ($job_state_ref->{"finished"} != 0) {
             if (!exists $job_state_ref->{"result"}) {
@@ -388,8 +400,13 @@ sub status
                         status_line => $self->{client}->status_line,
                         method_name => '_status_submit');
     }
+    my $async_job_check_time = $self->{async_job_check_time};
     while (1) {
-        Time::HiRes::sleep($self->{async_job_check_time});
+        Time::HiRes::sleep($async_job_check_time);
+        $async_job_check_time *= $self->{async_job_check_time_scale_percent} / 100.0;
+        if ($async_job_check_time > $self->{async_job_check_max_time}) {
+            $async_job_check_time = $self->{async_job_check_max_time};
+        }
         my $job_state_ref = $self->_check_job($job_id);
         if ($job_state_ref->{"finished"} != 0) {
             if (!exists $job_state_ref->{"result"}) {

--- a/src/java/us/kbase/templates/python_client.vm.properties
+++ b/src/java/us/kbase/templates/python_client.vm.properties
@@ -29,7 +29,8 @@ class ${module.module_name}(object):
             trust_all_ssl_certificates=False,
             auth_svc='https://kbase.us/services/authorization/Sessions/Login'#if($any_async || $async_version || $dynserv_ver),
             service_ver=#if($service_ver)'$service_ver'#{else}None#{end}#if($any_async || $async_version),
-            async_job_check_time_ms=5000#{end}#{end}):
+            async_job_check_time_ms=100, async_job_check_time_scale_percent=150, 
+            async_job_check_max_time_ms=300000#{end}#{end}):
         if url is None:
 #if( $default_service_url )
             url = '${default_service_url}'
@@ -46,7 +47,9 @@ class ${module.module_name}(object):
             token=token, ignore_authrc=ignore_authrc,
             trust_all_ssl_certificates=trust_all_ssl_certificates,
             auth_svc=auth_svc#if($any_async || $async_version),
-            async_job_check_time_ms=async_job_check_time_ms#{end}#if($dynserv_ver),
+            async_job_check_time_ms=async_job_check_time_ms,
+            async_job_check_time_scale_percent=async_job_check_time_scale_percent,
+            async_job_check_max_time_ms=async_job_check_max_time_ms#{end}#if($dynserv_ver),
             lookup_url=True#{end})
 #if($any_async || $async_version)
 
@@ -75,8 +78,13 @@ class ${module.module_name}(object):
         """
 #end
         job_id = self._${method.name}_submit(${method.args}#if($method.arg_count>0), #{end}context)
+        async_job_check_time = self._client.async_job_check_time
         while True:
-            time.sleep(self._client.async_job_check_time)
+            time.sleep(async_job_check_time)
+            async_job_check_time = (async_job_check_time *
+                self._client.async_job_check_time_scale_percent / 100.0)
+            if async_job_check_time > self._client.async_job_check_max_time:
+                async_job_check_time = self._client.async_job_check_max_time
             job_state = self._check_job(job_id)
             if job_state['finished']:
 #if( $method.ret_count == 1 )
@@ -107,8 +115,13 @@ class ${module.module_name}(object):
     def status(self, context=None):
         job_id = self._client._submit_job('${module.module_name}.status', 
             [], self._service_ver, context)
+        async_job_check_time = self._client.async_job_check_time
         while True:
-            time.sleep(self._client.async_job_check_time)
+            time.sleep(async_job_check_time)
+            async_job_check_time = (async_job_check_time *
+                self._client.async_job_check_time_scale_percent / 100.0)
+            if async_job_check_time > self._client.async_job_check_max_time:
+                async_job_check_time = self._client.async_job_check_max_time
             job_state = self._check_job(job_id)
             if job_state['finished']:
                 return job_state['result'][0]


### PR DESCRIPTION
Now in async call check cycle we start from 100 ms waiting and then multiply it by 1.5 every step. When it reaches 5 minutes (aprox. after 16 minutes in common) we keep it on 5 min. level.