### PR TITLE
Update python server for new auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /classes/
 /temp_*
 /ASimpleModule*
+/TestAsyncPerl/

--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,9 @@ sdkbase:
 	docker build --no-cache -t kbase/kbase:sdkbase.latest sdkbase
 
 test: submodule-init
-	@# todo: remove perl typecomp tests and add it as a separate target
 	@echo "Running unit tests"
+	nose2 -s test_scripts/py_module_tests -t src/java/us/kbase/templates
+	@# todo: remove perl typecomp tests and add it as a separate target
 	$(ANT) test
 
 test-client:

--- a/sdkbase/Dockerfile
+++ b/sdkbase/Dockerfile
@@ -1,5 +1,11 @@
 FROM kbase/deplbase:latest
 
+# Fix Python SSL warnings
+RUN apt-get install python-dev libffi-dev libssl-dev \
+    && pip install pyopenssl ndg-httpsclient pyasn1 \
+    && pip install requests --upgrade \
+    && pip install 'requests[security]' --upgrade
+
 # Update kb_sdk at build time
 ONBUILD RUN \
   . /kb/dev_container/user-env.sh && \

--- a/src/java/us/kbase/jkidl/SpecParser.java
+++ b/src/java/us/kbase/jkidl/SpecParser.java
@@ -797,7 +797,6 @@ name = nameToken.toString();
     throw generateParseException();
   }
 
-  @SuppressWarnings("serial")
   static private final class LookaheadSuccess extends java.lang.Error { }
   final private LookaheadSuccess jj_ls = new LookaheadSuccess();
   private boolean jj_scan_token(int kind) {

--- a/src/java/us/kbase/mobu/compiler/TemplateBasedGenerator.java
+++ b/src/java/us/kbase/mobu/compiler/TemplateBasedGenerator.java
@@ -1,6 +1,7 @@
 package us.kbase.mobu.compiler;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.Writer;
@@ -336,17 +337,26 @@ public class TemplateBasedGenerator {
                 output.openWriter(initPath).close();
             }
         }
-        final String baseCli = "baseclient.py";
-        final Path baseCliPath;
-        if (Paths.get(relativePyPath).getParent() == null) {
-            baseCliPath = Paths.get(baseCli);
+        
+        copyResourceFile(relativePyPath, output, "authclient.py");
+        copyResourceFile(relativePyPath, output, "baseclient.py");
+    }
+
+    private static void copyResourceFile(
+            final String relativePath,
+            final FileSaver output,
+            final String file)
+            throws IOException {
+        final Path filepath;
+        if (Paths.get(relativePath).getParent() == null) {
+            filepath = Paths.get(file);
         } else {
-            baseCliPath = Paths.get(relativePyPath).getParent()
-                    .resolve(baseCli);
+            filepath = Paths.get(relativePath).getParent()
+                    .resolve(file);
         }
         try (final InputStream input =
-                TemplateFormatter.getResource(baseCli);
-             final Writer w = output.openWriter(baseCliPath.toString())) {
+                TemplateFormatter.getResource(file);
+             final Writer w = output.openWriter(filepath.toString())) {
             IOUtils.copy(input, w);
         }
     }

--- a/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
+++ b/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
@@ -1,9 +1,7 @@
 package us.kbase.mobu.initializer.test;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileWriter;
-import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -12,9 +10,9 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
+import org.ini4j.Ini;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -23,6 +21,7 @@ import org.junit.BeforeClass;
 import us.kbase.auth.AuthService;
 import us.kbase.auth.AuthToken;
 import us.kbase.common.service.UObject;
+import us.kbase.common.test.TestException;
 import us.kbase.mobu.initializer.ModuleInitializer;
 import us.kbase.mobu.installer.ClientInstaller;
 import us.kbase.mobu.tester.ModuleTester;
@@ -37,15 +36,17 @@ public class DockerClientServerTester {
     protected static List<String> createdModuleNames = new ArrayList<String>();
     protected static String user;
     protected static String pwd;
+    
+    private static final String TEST_CFG = "kb_sdk_test";
 
     @BeforeClass
     public static void beforeTesterClass() throws Exception {
-        Properties props = new Properties();
-        InputStream is = new FileInputStream(new File("test_scripts/test.cfg"));
-        props.load(is);
-        is.close();
-        user = props.getProperty("test.user");
-        pwd = props.getProperty("test.pwd");
+        final Ini testini = new Ini(new File("test_scripts/test.cfg"));
+        user = testini.get(TEST_CFG, "test.user");
+        pwd = testini.get(TEST_CFG, "test.pwd");
+        if (user == null || user.isEmpty() || pwd == null || pwd.isEmpty()) {
+            throw new TestException("missing user and / or pwd from test cfg");
+        }
         TypeGeneratorTest.suppressJettyLogging();
     }
     

--- a/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
+++ b/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
@@ -45,7 +45,7 @@ public class DockerClientServerTester {
         user = testini.get(TEST_CFG, "test.user");
         pwd = testini.get(TEST_CFG, "test.pwd");
         if (user == null || user.isEmpty() || pwd == null || pwd.isEmpty()) {
-            throw new TestException("missing user and / or pwd from test cfg");
+            throw new TestException("missing user and / or pws from test cfg");
         }
         TypeGeneratorTest.suppressJettyLogging();
     }

--- a/src/java/us/kbase/mobu/installer/ClientInstaller.java
+++ b/src/java/us/kbase/mobu/installer/ClientInstaller.java
@@ -6,7 +6,6 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;

--- a/src/java/us/kbase/mobu/renamer/test/ModuleRenamerTest.java
+++ b/src/java/us/kbase/mobu/renamer/test/ModuleRenamerTest.java
@@ -34,7 +34,7 @@ public class ModuleRenamerTest {
         user = testini.get(TEST_CFG, "test.user");
         pwd = testini.get(TEST_CFG, "test.pwd");
         if (user == null || user.isEmpty() || pwd == null || pwd.isEmpty()) {
-            throw new TestException("missing user and / or pwd from test cfg");
+            throw new TestException("missing user and / or pws from test cfg");
         }
     }
 

--- a/src/java/us/kbase/mobu/renamer/test/ModuleRenamerTest.java
+++ b/src/java/us/kbase/mobu/renamer/test/ModuleRenamerTest.java
@@ -1,20 +1,19 @@
 package us.kbase.mobu.renamer.test;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 import junit.framework.Assert;
 
 import org.apache.commons.io.FileUtils;
+import org.ini4j.Ini;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import us.kbase.common.test.TestException;
 import us.kbase.mobu.initializer.ModuleInitializer;
 import us.kbase.mobu.renamer.ModuleRenamer;
 import us.kbase.mobu.tester.test.ModuleTesterTest;
@@ -25,17 +24,18 @@ public class ModuleRenamerTest {
     private static final List<File> dirsToRemove = new ArrayList<File>();
     private static final boolean deleteTempDirs = true;
 
+    private static final String TEST_CFG = "kb_sdk_test";
     private static String user;
     private static String pwd;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        Properties props = new Properties();
-        InputStream is = new FileInputStream(new File("test_scripts/test.cfg"));
-        props.load(is);
-        is.close();
-        user = props.getProperty("test.user");
-        pwd = props.getProperty("test.pwd");
+        final Ini testini = new Ini(new File("test_scripts/test.cfg"));
+        user = testini.get(TEST_CFG, "test.user");
+        pwd = testini.get(TEST_CFG, "test.pwd");
+        if (user == null || user.isEmpty() || pwd == null || pwd.isEmpty()) {
+            throw new TestException("missing user and / or pwd from test cfg");
+        }
     }
 
     @AfterClass

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -42,7 +42,6 @@ import us.kbase.mobu.util.ProcessHelper;
 import us.kbase.mobu.util.TextUtils;
 import us.kbase.mobu.validator.ModuleValidator;
 import us.kbase.templates.TemplateFormatter;
-import us.kbase.tools.WinShortPath;
 
 public class ModuleTester {
     private File moduleDir;

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -122,7 +122,7 @@ public class ModuleTester {
             return 1;
         }
         Properties props = new Properties();
-        InputStream is = new FileInputStream(new File(tlDir, "test.cfg"));
+        InputStream is = new FileInputStream(testCfg);
         try {
             props.load(is);
         } finally {

--- a/src/java/us/kbase/mobu/tester/test/ModuleTesterTest.java
+++ b/src/java/us/kbase/mobu/tester/test/ModuleTesterTest.java
@@ -35,7 +35,7 @@ public class ModuleTesterTest {
         user = testini.get(TEST_CFG, "test.user");
         pwd = testini.get(TEST_CFG, "test.pwd");
         if (user == null || user.isEmpty() || pwd == null || pwd.isEmpty()) {
-            throw new TestException("missing user and / or pwd from test cfg");
+            throw new TestException("missing user and / or pws from test cfg");
         }
     }
 

--- a/src/java/us/kbase/mobu/tester/test/ModuleTesterTest.java
+++ b/src/java/us/kbase/mobu/tester/test/ModuleTesterTest.java
@@ -1,20 +1,19 @@
 package us.kbase.mobu.tester.test;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 import junit.framework.Assert;
 
 import org.apache.commons.io.FileUtils;
+import org.ini4j.Ini;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import us.kbase.common.test.TestException;
 import us.kbase.mobu.ModuleBuilder;
 import us.kbase.mobu.initializer.ModuleInitializer;
 import us.kbase.mobu.tester.ModuleTester;
@@ -24,20 +23,22 @@ public class ModuleTesterTest {
 	private static final String SIMPLE_MODULE_NAME = "ASimpleModule_for_unit_testing";
 	private static final boolean cleanupAfterTests = true;
 	
+	private static final String TEST_CFG = "kb_sdk_test";
+	
 	private static List<String> createdModuleNames = new ArrayList<String>();
 	private static String user;
 	private static String pwd;
 	
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-	    Properties props = new Properties();
-	    InputStream is = new FileInputStream(new File("test_scripts/test.cfg"));
-	    props.load(is);
-	    is.close();
-	    user = props.getProperty("test.user");
-	    pwd = props.getProperty("test.pwd");
-	}
-	
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        final Ini testini = new Ini(new File("test_scripts/test.cfg"));
+        user = testini.get(TEST_CFG, "test.user");
+        pwd = testini.get(TEST_CFG, "test.pwd");
+        if (user == null || user.isEmpty() || pwd == null || pwd.isEmpty()) {
+            throw new TestException("missing user and / or pwd from test cfg");
+        }
+    }
+
 	@AfterClass
 	public static void tearDownModule() throws Exception {
 	    if (cleanupAfterTests)

--- a/src/java/us/kbase/mobu/util/ProcessHelper.java
+++ b/src/java/us/kbase/mobu/util/ProcessHelper.java
@@ -38,14 +38,11 @@ public class ProcessHelper {
     }
 
     public static ProcessHelper exec(CommandHolder cmd, File workDir, File input, File output, File error, boolean waitFor) throws IOException {
-        try ( // these SWs shouldn't be necessary, but there you go
-            @SuppressWarnings("resource")
+        try (
             final BufferedReader br = input == null ? null :
                 new BufferedReader(new FileReader(input));
-            @SuppressWarnings("resource")
             final PrintWriter pw = output == null ? null :
                 new PrintWriter(output);
-            @SuppressWarnings("resource")
             final PrintWriter epw = error == null ? null :
                 new PrintWriter(error)
         ) {

--- a/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
+++ b/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
@@ -2,7 +2,6 @@ package us.kbase.scripts.test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -19,7 +18,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -30,6 +28,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.ini4j.Ini;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -46,6 +45,7 @@ import us.kbase.common.service.JsonServerMethod;
 import us.kbase.common.service.JsonServerServlet;
 import us.kbase.common.service.ServerException;
 import us.kbase.common.service.UObject;
+import us.kbase.common.test.TestException;
 import us.kbase.kbasejobservice.KBaseJobServiceServer;
 import us.kbase.kidl.KbFuncdef;
 import us.kbase.kidl.KbService;
@@ -80,6 +80,7 @@ public class TypeGeneratorTest extends Assert {
     
 	public static final String rootPackageName = "us.kbase";
     public static final String tempDirName = "temp_test";
+    private static final String TEST_CFG = "kb_sdk_test";
     
     private static Boolean isCasperJsInstalled = null;
     private static String token = null;
@@ -100,17 +101,19 @@ public class TypeGeneratorTest extends Assert {
 		}
 	}
 	
-	@BeforeClass
-	public static void prepareTestConfigParams() throws Exception {
-		Properties props = new Properties();
-		InputStream is = new FileInputStream(new File("test_scripts/test.cfg"));
-		props.load(is);
-		is.close();
-		for (Object key : props.keySet()) {
-			String prop = key.toString();
-			String value = props.getProperty(prop);
-			System.setProperty(prop, value);
-		}
+    @BeforeClass
+    public static void prepareTestConfigParams() throws Exception {
+        final Ini testini = new Ini(new File("test_scripts/test.cfg"));
+        for (Object key: testini.get(TEST_CFG).keySet()) {
+            String prop = key.toString();
+            String value = testini.get(TEST_CFG, key);
+            System.setProperty(prop, value);
+        }
+        final String user = System.getProperty("test.user");
+        final String pwd = System.getProperty("test.pwd");
+        if (user == null || user.isEmpty() || pwd == null || pwd.isEmpty()) {
+            throw new TestException("missing user and / or pwd from test cfg");
+        }
         suppressJettyLogging();
 	}
 

--- a/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
+++ b/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
@@ -58,7 +58,6 @@ import us.kbase.mobu.compiler.JavaTypeGenerator;
 import us.kbase.mobu.compiler.PrevCodeParser;
 import us.kbase.mobu.compiler.RunCompileCommand;
 import us.kbase.mobu.util.DiskFileSaver;
-import us.kbase.mobu.util.FileSaver;
 import us.kbase.mobu.util.OneFileSaver;
 import us.kbase.mobu.util.ProcessHelper;
 import us.kbase.mobu.util.TextUtils;

--- a/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
+++ b/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
@@ -632,7 +632,8 @@ public class TypeGeneratorTest extends Assert {
 	private static void startTest(int testNum, boolean needJavaServer, boolean needPerlServer, boolean needPythonServer) throws Exception {
 		File workDir = prepareWorkDir(testNum);
 		System.out.println();
-		System.out.println("Test " + testNum + " (" + getCallingMethod() + ") is starting in directory: " + workDir.getName());
+		System.out.println("Test " + testNum + " (" + getCallingMethod() +
+		        ") is starting in directory: " + workDir.getAbsolutePath());
 		String testPackage = rootPackageName + ".test" + testNum;
 		File libDir = new File(workDir, "lib");
 		File binDir = new File(workDir, "bin");

--- a/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
+++ b/src/java/us/kbase/scripts/test/TypeGeneratorTest.java
@@ -112,7 +112,7 @@ public class TypeGeneratorTest extends Assert {
         final String user = System.getProperty("test.user");
         final String pwd = System.getProperty("test.pwd");
         if (user == null || user.isEmpty() || pwd == null || pwd.isEmpty()) {
-            throw new TestException("missing user and / or pwd from test cfg");
+            throw new TestException("missing user and / or pws from test cfg");
         }
         suppressJettyLogging();
 	}

--- a/src/java/us/kbase/templates/authclient.py
+++ b/src/java/us/kbase/templates/authclient.py
@@ -34,6 +34,10 @@ class TokenCache(object):
         return user
 
     def add_valid_token(self, token, user):
+        if not token:
+            raise ValueError('token cannot be None')
+        if not user:
+            raise ValueError('user cannot be None')
         with self._lock:
             self._cache[token] = [user, _time.time()]
             if len(self._cache) > self._maxsize:
@@ -62,6 +66,8 @@ class KBaseAuth(object):
         self._cache = TokenCache()
 
     def get_user(self, token):
+        if not token:
+            raise ValueError('token cannot be None')
         user = self._cache.get_user(token)
         if user:
             return user

--- a/src/java/us/kbase/templates/authclient.py
+++ b/src/java/us/kbase/templates/authclient.py
@@ -1,0 +1,82 @@
+'''
+Created on Aug 1, 2016
+
+A very basic KBase auth client for the Python server.
+
+@author: gaprice@lbl.gov
+'''
+import time as _time
+import requests as _requests
+import threading as _threading
+
+
+class TokenCache(object):
+    ''' A basic cache for tokens. '''
+
+    _MAX_TIME_SEC = 5 * 60  # 5 min
+
+    _lock = _threading.RLock()
+
+    def __init__(self, maxsize=2000):
+        self._cache = {}
+        self._maxsize = maxsize
+        self._halfmax = maxsize / 2  # int division to round down
+
+    def get_user(self, token):
+        with self._lock:
+            usertime = self._cache.get(token)
+        if not usertime:
+            return None
+
+        user, intime = usertime
+        if _time.time() - intime > self._MAX_TIME_SEC:
+            return None
+        return user
+
+    def add_valid_token(self, token, user):
+        with self._lock:
+            self._cache[token] = [user, _time.time()]
+            if len(self._cache) > self._maxsize:
+                for i, (t, _) in enumerate(sorted(self._cache.items(),
+                                                  key=lambda (_, v): v[1])):
+                    if i <= self._halfmax:
+                        del self._cache[t]
+                    else:
+                        break
+
+
+class KBaseAuth(object):
+    '''
+    A very basic KBase auth client for the Python server.
+    '''
+
+    _LOGIN_URL = 'https://kbase.us/services/authorization/Sessions/Login'
+
+    def __init__(self, auth_url=None):
+        '''
+        Constructor
+        '''
+        self._authurl = auth_url
+        if not self._authurl:
+            self._authurl = self._LOGIN_URL
+        self._cache = TokenCache()
+
+    def get_user(self, token):
+        user = self._cache.get_user(token)
+        if user:
+            return user
+
+        d = {'token': token, 'fields': 'user_id'}
+        ret = _requests.post(self._authurl, data=d)
+        if not ret.ok:
+            try:
+                err = ret.json()
+            except:
+                ret.raise_for_status()
+            raise ValueError('Error connecting to auth service: {} {}\n{}'
+                             .format(ret.status_code, ret.reason,
+                                     err['error_msg']))
+
+        user = ret.json()['user_id']
+        self._cache.add_valid_token(token, user)
+        return user

--- a/src/java/us/kbase/templates/baseclient.py
+++ b/src/java/us/kbase/templates/baseclient.py
@@ -137,7 +137,8 @@ class BaseClient(object):
         self.trust_all_ssl_certificates = trust_all_ssl_certificates
         self.lookup_url = lookup_url
         self.async_job_check_time = async_job_check_time_ms / 1000.0
-        self.async_job_check_time_scale_percent = async_job_check_time_scale_percent
+        self.async_job_check_time_scale_percent = (
+            async_job_check_time_scale_percent)
         self.async_job_check_max_time = async_job_check_max_time_ms / 1000.0
         # token overrides user_id and password
         if token is not None:
@@ -238,7 +239,8 @@ class BaseClient(object):
         while True:
             time.sleep(async_job_check_time)
             async_job_check_time = (async_job_check_time *
-                self.async_job_check_time_scale_percent / 100.0)
+                                    self.async_job_check_time_scale_percent /
+                                    100.0)
             if async_job_check_time > self.async_job_check_max_time:
                 async_job_check_time = self.async_job_check_max_time
             job_state = self._check_job(mod, job_id)

--- a/src/java/us/kbase/templates/python_client.vm.properties
+++ b/src/java/us/kbase/templates/python_client.vm.properties
@@ -129,7 +129,7 @@ class ${module.module_name}(object):
 
     def status(self, context=None):
         return self._client.call_method('${module.module_name}.status',
-            [], self._service_ver, context)
+                                        [], self._service_ver, context)
 #end## of if-status-async
 #end## of if-not-status
 #end## of foreach module

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -429,7 +429,7 @@ class Application(object):
                         if token is None and auth_req == 'required':
                             err = JSONServerError()
                             err.data = (
-                                'Authentication required for ${last_module.module_name} ' + 
+                                'Authentication required for ${last_module.module_name} ' +
                                 'but no authentication header was passed')
                             raise err
                         elif token is None and auth_req == 'optional':

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -26,6 +26,7 @@ SERVICE = 'KB_SERVICE_NAME'
 
 # Note that the error fields do not match the 2.0 JSONRPC spec
 
+
 def get_config_file():
     return environ.get(DEPLOY, None)
 
@@ -57,7 +58,7 @@ config = get_config()
 #set( $void = $specToPy.put("UnspecifiedObject", "object") )
 #foreach( $module in $modules )
 #set( $mn = $module.module_name )
-from ${module.pymodule} import ${mn}
+from ${module.pymodule} import ${mn}  # @IgnorePep8
 impl_${mn} = ${mn}(config)
 #end
 
@@ -406,9 +407,15 @@ class Application(object):
             else:
                 ctx['module'], ctx['method'] = req['method'].split('.')
                 ctx['call_id'] = req['id']
-                ctx['rpc_context'] = {'call_stack': [{'time':self.now_in_utc(), 'method': req['method']}]}
-                prov_action = {'service': ctx['module'], 'method': ctx['method'], 
-                               'method_params': req['params']}
+                ctx['rpc_context'] = {
+                    'call_stack': [{'time': self.now_in_utc(),
+                                    'method': req['method']}
+                                   ]
+                }
+                prov_action = {'service': ctx['module'],
+                               'method': ctx['method'],
+                               'method_params': req['params']
+                               }
                 ctx['provenance'] = [prov_action]
                 try:
 #if( $authenticated )
@@ -416,13 +423,14 @@ class Application(object):
                     # parse out the method being requested and check if it
                     # has an authentication requirement
                     method_name = req['method']
-                    auth_req = self.method_authentication.get(method_name,
-                                                              "none")
-                    if auth_req != "none":
+                    auth_req = self.method_authentication.get(
+                        method_name, 'none')
+                    if auth_req != 'none':
                         if token is None and auth_req == 'required':
                             err = JSONServerError()
-                            err.data = "Authentication required for " + \
-                                "${last_module.module_name} but no authentication header was passed"
+                            err.data = (
+                                'Authentication required for ${last_module.module_name} ' + 
+                                'but no authentication header was passed')
                             raise err
                         elif token is None and auth_req == 'optional':
                             pass
@@ -492,7 +500,8 @@ class Application(object):
             error['id'] = request['id']
         if 'version' in request:
             error['version'] = request['version']
-            if 'error' not in error['error'] or error['error']['error'] is None:
+            e = error['error'].get('error')
+            if not e:
                 error['error']['error'] = trace
         elif 'jsonrpc' in request:
             error['jsonrpc'] = request['jsonrpc']
@@ -503,11 +512,11 @@ class Application(object):
         return json.dumps(error)
 
     def now_in_utc(self):
-        # Taken from http://stackoverflow.com/questions/3401428/how-to-get-an-isoformat-datetime-string-including-the-default-timezone
+        # Taken from http://stackoverflow.com/questions/3401428/how-to-get-an-isoformat-datetime-string-including-the-default-timezone @IgnorePep8
         dtnow = datetime.datetime.now()
         dtutcnow = datetime.datetime.utcnow()
         delta = dtnow - dtutcnow
-        hh,mm = divmod((delta.days * 24*60*60 + delta.seconds + 30) // 60, 60)
+        hh, mm = divmod((delta.days * 24*60*60 + delta.seconds + 30) // 60, 60)
         return "%s%+02d:%02d" % (dtnow.isoformat(), hh, mm)
 
 application = Application()
@@ -574,13 +583,14 @@ def stop_server():
     _proc.terminate()
     _proc = None
 
+
 def process_async_cli(input_file_path, output_file_path, token):
     exit_code = 0
-    with open(input_file_path) as data_file:    
+    with open(input_file_path) as data_file:
         req = json.load(data_file)
     if 'version' not in req:
         req['version'] = '1.1'
-    if 'id' not in req: 
+    if 'id' not in req:
         req['id'] = str(_random.random())[2:]
     ctx = MethodContext(application.userlog)
 #if( $authenticated )
@@ -594,7 +604,7 @@ def process_async_cli(input_file_path, output_file_path, token):
         ctx['rpc_context'] = req['context']
     ctx['CLI'] = 1
     ctx['module'], ctx['method'] = req['method'].split('.')
-    prov_action = {'service': ctx['module'], 'method': ctx['method'], 
+    prov_action = {'service': ctx['module'], 'method': ctx['method'],
                    'method_params': req['params']}
     ctx['provenance'] = [prov_action]
     resp = None
@@ -608,8 +618,8 @@ def process_async_cli(input_file_path, output_file_path, token):
                           'name': jre.message,
                           'message': jre.data,
                           'error': trace}
-               }
-    except Exception, e:
+                }
+    except Exception:
         trace = traceback.format_exc()
         resp = {'id': req['id'],
                 'version': req['version'],
@@ -617,20 +627,21 @@ def process_async_cli(input_file_path, output_file_path, token):
                           'name': 'Unexpected Server Error',
                           'message': 'An unexpected server error occurred',
                           'error': trace}
-               }
+                }
     if 'error' in resp:
         exit_code = 500
     with open(output_file_path, "w") as f:
         f.write(json.dumps(resp, cls=JSONObjectEncoder))
     return exit_code
-    
+
 if __name__ == "__main__":
     requests.packages.urllib3.disable_warnings()
-    if len(sys.argv) >= 3 and len(sys.argv) <= 4 and os.path.isfile(sys.argv[1]):
+    if (len(sys.argv) >= 3 and len(sys.argv) <= 4 and
+            os.path.isfile(sys.argv[1])):
         token = None
         if len(sys.argv) == 4:
             if os.path.isfile(sys.argv[3]):
-                with open(sys.argv[3]) as token_file: 
+                with open(sys.argv[3]) as token_file:
                     token = token_file.read()
             else:
                 token = sys.argv[3]

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -16,7 +16,6 @@ from biokbase import log
 import requests as _requests
 import random as _random
 import os
-import requests.packages.urllib3
 #if( $authenticated )
 # the following is a hack to get the authclient to import whether we're in a
 # package or not. This makes pep8 unhappy hence the annotations.
@@ -639,7 +638,6 @@ def process_async_cli(input_file_path, output_file_path, token):
     return exit_code
 
 if __name__ == "__main__":
-    requests.packages.urllib3.disable_warnings()
     if (len(sys.argv) >= 3 and len(sys.argv) <= 4 and
             os.path.isfile(sys.argv[1])):
         token = None

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -13,16 +13,24 @@ from jsonrpcbase import ServerError as JSONServerError
 from os import environ
 from ConfigParser import ConfigParser
 from biokbase import log
-#if( $authenticated )
-import biokbase.nexus
-#end
 import requests as _requests
 import random as _random
 import os
 import requests.packages.urllib3
+#if( $authenticated )
+# the following is a hack to get the authclient to import whether we're in a
+# package or not. This makes pep8 unhappy hence the annotations.
+try:
+    # authclient and this client are in a package
+    from .authclient import KBaseAuth as _KBaseAuth  # @UnusedImport
+except:
+    # no they aren't
+    from authclient import KBaseAuth as _KBaseAuth  # @Reimport
+#end
 
 DEPLOY = 'KB_DEPLOYMENT_CONFIG'
 SERVICE = 'KB_SERVICE_NAME'
+AUTH = 'auth-server-url'
 
 # Note that the error fields do not match the 2.0 JSONRPC spec
 
@@ -372,11 +380,8 @@ class Application(object):
 #end
 #end
 #if( $authenticated )
-        self.auth_client = biokbase.nexus.Client(
-            config={'server': 'nexus.api.globusonline.org',
-                    'verify_ssl': True,
-                    'client': None,
-                    'client_secret': None})
+        authurl = config.get(AUTH) if config else None
+        self.auth_client = _KBaseAuth(authurl)
 #end
 
     def __call__(self, environ, start_response):
@@ -436,8 +441,7 @@ class Application(object):
                             pass
                         else:
                             try:
-                                user, _, _ = \
-                                    self.auth_client.validate_token(token)
+                                user = self.auth_client.get_user(token)
                                 ctx['user_id'] = user
                                 ctx['authenticated'] = 1
                                 ctx['token'] = token
@@ -595,7 +599,7 @@ def process_async_cli(input_file_path, output_file_path, token):
     ctx = MethodContext(application.userlog)
 #if( $authenticated )
     if token:
-        user, _, _ = application.auth_client.validate_token(token)
+        user = application.auth_client.get_user(token)
         ctx['user_id'] = user
         ctx['authenticated'] = 1
         ctx['token'] = token

--- a/test_dependencies.md
+++ b/test_dependencies.md
@@ -1,0 +1,3 @@
+Known test dependencies listed below. Please add more if discovered.
+
+pip install nose2

--- a/test_scripts/py_module_tests/test_auth_client.py
+++ b/test_scripts/py_module_tests/test_auth_client.py
@@ -1,0 +1,85 @@
+'''
+Created on Aug 2, 2016
+
+@author: gaprice@lbl.gov
+'''
+from __future__ import print_function
+
+import unittest
+
+from authclient import KBaseAuth  # @UnresolvedImport
+import os
+# can't use configparser here because doesn't allow cfgs with no sections
+from configobj import ConfigObj
+import requests
+from requests import ConnectionError
+
+
+class TestAuth(unittest.TestCase):
+
+    AUTHURL = 'test.auth.url'
+    TOKEN1 = 'test.token1'
+    TOKEN2 = 'test.token2'
+
+    @classmethod
+    def setUpClass(cls):
+        configfile = os.path.abspath(os.path.dirname(
+            os.path.abspath(__file__)) + '/../test.cfg')
+        print('Loading test config from ' + configfile)
+        cfg = ConfigObj(configfile)
+        authurl = cfg.get(cls.AUTHURL)
+        cls.token1 = cfg.get(cls.TOKEN1)
+        cls.token2 = cfg.get(cls.TOKEN2)
+        if not authurl:
+            raise ValueError('Missing {} from test config'.format(cls.AUTHURL))
+        if not cls.token1:
+            raise ValueError('Missing {} from test config'.format(cls.TOKEN1))
+        if not cls.token2:
+            raise ValueError('Missing {} from test config'.format(cls.TOKEN2))
+        cls.user1 = cls.get_user(authurl, cls.token1)
+        cls.user2 = cls.get_user(authurl, cls.token2)
+        if cls.user1 == cls.user2:
+            raise ValueError('{} and {} users are the same: {}'.format(
+                cls.TOKEN1, cls.TOKEN2, cls.user1))
+        cls.kba = KBaseAuth(authurl)
+
+    @classmethod
+    def get_user(cls, authurl, token):
+        d = {'token': token, 'fields': 'user_id'}
+        ret = requests.post(authurl, data=d)
+        return ret.json()['user_id']
+
+    def test_get_user(self):
+        self.assertEqual(self.kba.get_user(self.token1), self.user1)
+        self.assertEqual(self.kba.get_user(self.token2), self.user2)
+
+        # test getting from cache
+        self.assertEqual(self.kba.get_user(self.token1), self.user1)
+        self.assertEqual(self.kba.get_user(self.token2), self.user2)
+
+        # test default url
+        kba2 = KBaseAuth()
+        self.assertEqual(kba2.get_user(self.token1), self.user1)
+        self.assertEqual(kba2.get_user(self.token2), self.user2)
+
+    def test_bad_token(self):
+        self.fail_get_user(None, 'token cannot be None')
+        self.fail_get_user(
+            'bleah', 'Error connecting to auth service: 500 ' +
+            'INTERNAL SERVER ERROR\nValueError: need more than 1 value to ' +
+            'unpack')
+        self.fail_get_user(
+            self.token1 + 'a', 'Error connecting to auth service: 401 ' +
+            'UNAUTHORIZED\nLoginFailure: Invalid token')
+
+    def test_bad_url(self):
+        kba2 = KBaseAuth('https://thisisasuperfakeurlihope.com')
+        with self.assertRaises(ConnectionError) as context:
+            kba2.get_user(self.token1)
+        self.assertTrue(str(context.exception.message).startswith(
+            "HTTPSConnectionPool(host='thisisasuperfakeurlihope.com'"))
+
+    def fail_get_user(self, token, error):
+        with self.assertRaises(ValueError) as context:
+            self.kba.get_user(token)
+        self.assertEqual(error, str(context.exception.message))

--- a/test_scripts/py_module_tests/test_auth_client.py
+++ b/test_scripts/py_module_tests/test_auth_client.py
@@ -9,8 +9,7 @@ import unittest
 
 from authclient import KBaseAuth  # @UnresolvedImport
 import os
-# can't use configparser here because doesn't allow cfgs with no sections
-from configobj import ConfigObj
+from ConfigParser import ConfigParser
 import requests
 from requests import ConnectionError
 
@@ -21,15 +20,18 @@ class TestAuth(unittest.TestCase):
     TOKEN1 = 'test.token1'
     TOKEN2 = 'test.token2'
 
+    CFG_SEC = 'kb_sdk_test'
+
     @classmethod
     def setUpClass(cls):
         configfile = os.path.abspath(os.path.dirname(
             os.path.abspath(__file__)) + '/../test.cfg')
         print('Loading test config from ' + configfile)
-        cfg = ConfigObj(configfile)
-        authurl = cfg.get(cls.AUTHURL)
-        cls.token1 = cfg.get(cls.TOKEN1)
-        cls.token2 = cfg.get(cls.TOKEN2)
+        cfg = ConfigParser()
+        cfg.read(configfile)
+        authurl = cfg.get(cls.CFG_SEC, cls.AUTHURL)
+        cls.token1 = cfg.get(cls.CFG_SEC, cls.TOKEN1)
+        cls.token2 = cfg.get(cls.CFG_SEC, cls.TOKEN2)
         if not authurl:
             raise ValueError('Missing {} from test config'.format(cls.AUTHURL))
         if not cls.token1:
@@ -76,8 +78,9 @@ class TestAuth(unittest.TestCase):
         kba2 = KBaseAuth('https://thisisasuperfakeurlihope.com')
         with self.assertRaises(ConnectionError) as context:
             kba2.get_user(self.token1)
-        self.assertTrue(str(context.exception.message).startswith(
-            "HTTPSConnectionPool(host='thisisasuperfakeurlihope.com'"))
+        self.assertIn(
+            "HTTPSConnectionPool(host='thisisasuperfakeurlihope.com'",
+            str(context.exception.message))
 
     def fail_get_user(self, token, error):
         with self.assertRaises(ValueError) as context:

--- a/test_scripts/py_module_tests/test_auth_client.py
+++ b/test_scripts/py_module_tests/test_auth_client.py
@@ -78,9 +78,7 @@ class TestAuth(unittest.TestCase):
         kba2 = KBaseAuth('https://thisisasuperfakeurlihope.com')
         with self.assertRaises(ConnectionError) as context:
             kba2.get_user(self.token1)
-        self.assertIn(
-            "HTTPSConnectionPool(host='thisisasuperfakeurlihope.com'",
-            str(context.exception.message))
+        self.assertIn('not known', str(context.exception.message))
 
     def fail_get_user(self, token, error):
         with self.assertRaises(ValueError) as context:

--- a/test_scripts/py_module_tests/test_token_cache.py
+++ b/test_scripts/py_module_tests/test_token_cache.py
@@ -1,0 +1,57 @@
+'''
+Created on Aug 2, 2016
+
+@author: gaprice@lbl.gov
+'''
+import unittest
+
+from authclient import TokenCache  # @UnresolvedImport
+import time
+
+
+class TestTokenCache(unittest.TestCase):
+
+    def test_set_and_get(self):
+        tc = TokenCache()
+        tc.add_valid_token('foo', 'bar')
+        self.assertEqual('bar', tc.get_user('foo'))
+        tc.add_valid_token('baz', 'bat')
+        self.assertEqual('bat', tc.get_user('baz'))
+        self.assertEqual(None, tc.get_user('womp'))
+
+    def test_fail_set(self):
+        self.fail_set(None, 'foo', 'token cannot be None')
+        self.fail_set('foo', None, 'user cannot be None')
+
+    def test_fast_expire(self):
+        tc = TokenCache()
+        tc._MAX_TIME_SEC = 1
+        tc.add_valid_token('foo', 'bar')
+        self.assertEqual('bar', tc.get_user('foo'))
+        time.sleep(2)
+        self.assertEqual(None, tc.get_user('foo'))
+
+    def test_drop_tokens(self):
+        sz = 4
+        tc = TokenCache(sz)
+        for x in xrange(1, sz + 1):
+            tc.add_valid_token(x, str(x))
+        for x in xrange(1, sz + 1):
+            self.assertEqual(str(x), tc.get_user(x))
+
+        # shouldn't dump the cache
+        tc.add_valid_token(2, '2')
+        for x in xrange(1, sz + 1):
+            self.assertEqual(str(x), tc.get_user(x))
+
+        # should dump the cache
+        tc.add_valid_token(5, '5')
+        for x in [1, 3, 4]:
+            self.assertEqual(None, tc.get_user(x))
+        for x in [2, 5]:
+            self.assertEqual(str(x), tc.get_user(x))
+
+    def fail_set(self, token, user, error):
+        with self.assertRaises(ValueError) as context:
+            TokenCache().add_valid_token(token, user)
+        self.assertEqual(error, str(context.exception.message))

--- a/test_scripts/test.cfg
+++ b/test_scripts/test.cfg
@@ -1,2 +1,6 @@
 test.user=kbasetest
 test.pwd=*****
+# these must be different users
+test.token1=
+test.token2=
+test.auth.url=https://kbase.us/services/authorization/Sessions/Login

--- a/test_scripts/test.cfg
+++ b/test_scripts/test.cfg
@@ -1,3 +1,4 @@
+[kb_sdk_test]
 test.user=kbasetest
 test.pwd=*****
 # these must be different users


### PR DESCRIPTION
Also some pep8ification.
Also fixed the python SSL warnings.

* new simple auth client
* uses KBase auth server vs. globus
* auth-service-url in deploy.cfg now sets kbase auth url

TODO:
* [x] auth client tests, incl. token cache