### PR TITLE
Fix python import & failing tests

### DIFF
--- a/src/java/us/kbase/kidl/KbService.java
+++ b/src/java/us/kbase/kidl/KbService.java
@@ -75,7 +75,16 @@ public class KbService {
 		for (Map<String, Object> module : modules) {
 			String moduleName = (String)module.get("module_name");
 			module.put("impl_package_name", perlImplName == null ? (moduleName + "Impl") : perlImplName);
-			module.put("pymodule", pythonImplName == null ? (moduleName + "Impl") : pythonImplName);
+			final String pymod = pythonImplName == null ?
+					(moduleName + "Impl") : pythonImplName;
+			module.put("pymodule", pymod);
+			final String pypkg;
+			if (pymod.lastIndexOf(".") > 0) {
+				pypkg = pymod.substring(0, pymod.lastIndexOf(".")) + ".";
+			} else {
+				pypkg = "";
+			}
+			module.put("pypackage", pypkg);
 		}
 		ret.put("modules", modules);
 		if (psbl)

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -17,14 +17,7 @@ import requests as _requests
 import random as _random
 import os
 #if( $authenticated )
-# the following is a hack to get the authclient to import whether we're in a
-# package or not. This makes pep8 unhappy hence the annotations.
-try:
-    # authclient and this client are in a package
-    from .authclient import KBaseAuth as _KBaseAuth  # @UnusedImport
-except:
-    # no they aren't
-    from authclient import KBaseAuth as _KBaseAuth  # @Reimport
+from ${modules[0].pypackage}authclient import KBaseAuth as _KBaseAuth
 #end
 
 DEPLOY = 'KB_DEPLOYMENT_CONFIG'


### PR DESCRIPTION
Currently the python SDK server/ async runner is broken due to an import problem that was not picked up by the tests.

There's a problem with the kb_sdk tests - they build a docker container to run some of the tests, but that docker container pulls from github.com/kbase/kb_sdk develop to build the sdk. Hence, the tests don't actually test the changes you've made to kb_sdk and only start failing *after* your PR has been merged to develop. 

The workaround is to 1) push your changes to your repo 2) alter the sdkbase dockerfile to pull sdk from your repo, and 3) run tests. It's going to be really easy to forget to do this, though.