### PR TITLE
Added coverage tracking to Python test harness

### DIFF
--- a/sdkbase/Dockerfile
+++ b/sdkbase/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get install python-dev libffi-dev libssl-dev \
     && pip install pyopenssl ndg-httpsclient pyasn1 \
     && pip install requests --upgrade \
     && pip install requests_toolbelt --upgrade \
-    && pip install 'requests[security]' --upgrade
+    && pip install 'requests[security]' --upgrade \
+    && pip install coverage
 
 # Update kb_sdk at build time
 ONBUILD RUN \
@@ -21,4 +22,3 @@ ONBUILD RUN \
   make && make deploy && \
   cd /kb/dev_container/modules/kb_sdk && \
   make && make deploy
-

--- a/src/java/us/kbase/templates/module_makefile.vm.properties
+++ b/src/java/us/kbase/templates/module_makefile.vm.properties
@@ -128,7 +128,7 @@ build-test-script:
 #if($language == "python")
 	echo 'export PYTHONPATH=$$script_dir/../$(LIB_DIR):$$PATH:$$PYTHONPATH' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'cd $$script_dir/../$(TEST_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'python -u -m unittest discover -p "*_test.py"' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
+	echo 'python -m nose --with-coverage --cover-package=$(SERVICE_CAPS) --cover-html --cover-html-dir=/kb/module/work/test_coverage .' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 #end
 #if($language == "java")
 	echo 'export JAVA_HOME=$(JAVA_HOME)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
@@ -147,4 +147,3 @@ test:
 
 clean:
 	rm -rfv $(LBIN_DIR)
-	


### PR DESCRIPTION
This adds the Python coverage module to the sdkbase Docker image, and rewires the generated Python test script to run nose with coverage.

It's set (by default) to only do coverage on the existing module. That's based on the ServiceCaps variable in the Makefile, which seems to always be the main module name, but it might change.

It also generates the coverage html output and puts it in the working directory. For the testing user, this'll land in test_local/workdir/test_coverage. index.html is the entrypoint to browse what's covered. 