### PR TITLE
Got rid of contact help@kbase.us in example spec.json

### DIFF
--- a/doc/kb_sdk_edit_module.md
+++ b/doc/kb_sdk_edit_module.md
@@ -393,7 +393,7 @@ Edit *spec.json*:
 	"authors": [
 		"YourName"
 	],
-	"contact": "help@kbase.us",
+	"contact": "http://yourwebsite.org/",
 	"visible": true,
 	"categories": ["active","assembly","communities"],
 	"widgets": {


### PR DESCRIPTION
I already did this in the develop branch but no one will tell me whether commits to this repo should go into develop or master.