### PR TITLE
Don't make /kb/module globally executable

### DIFF
--- a/src/java/us/kbase/mobu/tester/SDKSubsequentCallRunner.java
+++ b/src/java/us/kbase/mobu/tester/SDKSubsequentCallRunner.java
@@ -1,7 +1,6 @@
 package us.kbase.mobu.tester;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -14,7 +13,6 @@ import java.util.UUID;
 import us.kbase.auth.AuthToken;
 import us.kbase.catalog.ModuleVersion;
 import us.kbase.common.executionengine.ModuleMethod;
-import us.kbase.common.executionengine.ModuleRunVersion;
 import us.kbase.common.executionengine.SubsequentCallRunner;
 import us.kbase.common.executionengine.CallbackServerConfigBuilder.CallbackServerConfig;
 import us.kbase.common.service.JsonClientException;

--- a/src/java/us/kbase/templates/module_dockerfile.vm.properties
+++ b/src/java/us/kbase/templates/module_dockerfile.vm.properties
@@ -25,7 +25,7 @@ RUN apt-get -y install r-cran-evaluate r-cran-codetools r-cran-testthat
 
 COPY ./ /kb/module
 RUN mkdir -p /kb/module/work
-RUN chmod -R 777 /kb/module
+RUN chmod -R a+rw /kb/module
 
 WORKDIR /kb/module
 


### PR DESCRIPTION
Kills python tests in new modules