### PR TITLE
added exit code to runTestCommand

### DIFF
--- a/src/java/us/kbase/mobu/ModuleBuilder.java
+++ b/src/java/us/kbase/mobu/ModuleBuilder.java
@@ -343,7 +343,7 @@ public class ModuleBuilder {
     private static int runTestCommand(TestCommandArgs testArgs, JCommander jc) {
         // Figure out module name.
         // Join together spaced out names with underscores if necessary.
-        int returnCode = 131;
+        int returnCode = 1;
 
         try {
             ModuleTester tester = new ModuleTester();

--- a/src/java/us/kbase/mobu/ModuleBuilder.java
+++ b/src/java/us/kbase/mobu/ModuleBuilder.java
@@ -343,17 +343,20 @@ public class ModuleBuilder {
     private static int runTestCommand(TestCommandArgs testArgs, JCommander jc) {
         // Figure out module name.
         // Join together spaced out names with underscores if necessary.
+        int returnCode = 131;
+
         try {
             ModuleTester tester = new ModuleTester();
-            tester.runTests(testArgs.methodStoreUrl, testArgs.skipValidation, testArgs.allowSyncMethods);
+            returnCode = tester.runTests(testArgs.methodStoreUrl, testArgs.skipValidation, testArgs.allowSyncMethods);
         }
         catch (Exception e) {
             if (testArgs.verbose)
                 e.printStackTrace();
             showError("Error while testing module", e.getMessage());
-            return 1;
+            return returnCode;
         }
-        return 0;
+
+        return returnCode;
     }
 
     private static void printVersion() {


### PR DESCRIPTION
Added code to return a non-zero exit code when unit tests are executed.

Currently, the 0 exit code is returned even when unit tests fail. 

This affects travis test reporting when integration tests are built using a call to 'kb-sdk test'.
