### PR TITLE
Fix python auth client & tests

### DIFF
--- a/src/java/us/kbase/templates/authclient.py
+++ b/src/java/us/kbase/templates/authclient.py
@@ -57,7 +57,7 @@ class KBaseAuth(object):
     A very basic KBase auth client for the Python server.
     '''
 
-    _LOGIN_URL = 'https://kbase.us/services/authorization/Sessions/Login'
+    _LOGIN_URL = 'https://kbase.us/services/auth/api/legacy/KBase/Sessions/Login'
 
     def __init__(self, auth_url=None):
         '''
@@ -84,7 +84,7 @@ class KBaseAuth(object):
                 ret.raise_for_status()
             raise ValueError('Error connecting to auth service: {} {}\n{}'
                              .format(ret.status_code, ret.reason,
-                                     err['error_msg']))
+                                     err['error']['message']))
 
         user = ret.json()['user_id']
         self._cache.add_valid_token(token, user)

--- a/test_scripts/py_module_tests/test_auth_client.py
+++ b/test_scripts/py_module_tests/test_auth_client.py
@@ -59,20 +59,18 @@ class TestAuth(unittest.TestCase):
         self.assertEqual(self.kba.get_user(self.token1), self.user1)
         self.assertEqual(self.kba.get_user(self.token2), self.user2)
 
-        # test default url
-        kba2 = KBaseAuth()
-        self.assertEqual(kba2.get_user(self.token1), self.user1)
-        self.assertEqual(kba2.get_user(self.token2), self.user2)
+        # Only test the default url manually, since it runs against production.
+        # kba2 = KBaseAuth()
+        # self.assertEqual(kba2.get_user(self.token1), self.user1)
+        # self.assertEqual(kba2.get_user(self.token2), self.user2)
 
     def test_bad_token(self):
         self.fail_get_user(None, 'Must supply token')
         self.fail_get_user(
-            'bleah', 'Error connecting to auth service: 500 ' +
-            'INTERNAL SERVER ERROR\nValueError: need more than 1 value to ' +
-            'unpack')
+            'bleah', 'Error connecting to auth service: 401 Unauthorized\n10020 Invalid token')
         self.fail_get_user(
-            self.token1 + 'a', 'Error connecting to auth service: 401 ' +
-            'UNAUTHORIZED\nLoginFailure: Invalid token')
+            self.token1 + 'a',
+            'Error connecting to auth service: 401 Unauthorized\n10020 Invalid token')
 
     def test_bad_url(self):
         kba2 = KBaseAuth('https://thisisasuperfakeurlihope.com')


### PR DESCRIPTION
Looks like the auth client was never compatible with with auth2 error
syntax. No need to support auth1 at this point.

Later, update the client to use the new auth2 api rather than the legacy
api, including implementing the suggested cache time.

Tested that the default url works manually.