### PR TITLE
TASK-935: Callback server failhard

### DIFF
--- a/JAR_DEPS
+++ b/JAR_DEPS
@@ -12,6 +12,7 @@ apache_commons/http/httpcore-4.3.jar
 apache_commons/http/httpmime-4.3.1.jar
 apache_commons/velocity-1.7.jar
 codemodel/codemodel-2.4.1.jar
+cglib/cglib-nodep-2.2.jar
 google/guava-18.0.jar
 google/jsonschema2pojo-core-0.3.6.jar
 ini4j/ini4j-0.5.2.jar
@@ -19,6 +20,7 @@ j2html/j2html-0.7.jar
 jackson/jackson-annotations-2.2.3.jar
 jackson/jackson-core-2.2.3.jar
 jackson/jackson-databind-2.2.3.jar
+javassist/javassist-3.20.0-GA.jar
 jcommander/jcommander-1.48.jar
 jetty/jetty-all-7.0.0.jar
 jna/jna-3.4.0.jar
@@ -32,6 +34,9 @@ kbase/workspace/WorkspaceClient-0.6.0.jar
 kohsuke/args4j-2.0.21.jar
 logback/logback-classic-1.1.2.jar
 logback/logback-core-1.1.2.jar
+mockito/mockito-all-2.0.2-beta.jar
+objenesis/objenesis-2.5.1.jar
+powermock-full/powermock-mockito2-1.7.0-full.jar
 servlet/servlet-api-2.5.jar
 slf4j/slf4j-api-1.7.7.jar
 snakeyaml/snakeyaml-1.11.jar

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can use the SDK to develop and test Apps with a regular KBase user account (
 
 ## <A NAME="steps"></A>Steps in Using SDK
 1. [Install SDK Dependencies](doc/kb_sdk_dependencies.md)
-2. [Install and Build SDK](doc/kb_sdk_install_and_build.md)
+2. [Install SDK with Docker](doc/kb_sdk_dockerized_install.md)
 3. [Create Module](doc/kb_sdk_create_module.md)
 4. [Edit Module and Method(s)](doc/kb_sdk_edit_module.md)
 5. [Locally Test Module and Method(s)](doc/kb_sdk_local_test_module.md)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ There are still some general restrictions on functionality that will gradually b
 
 If you have a tool you would like to register with KBase that cannot meet these requirements, please <a href="http://kbase.us/contact-us">contact us</a> to discuss possible solutions.
 
-You can use the SDK to develop and locally test Apps with a regular KBase user account (and a Git repository). However in order to deploy your app into a narrative you will need to <a href="http://kbase.us/contact-us">contact us</a>  to be added to the developer list.
+In order to use the SDK to test and deploy Apps you will need developer credentials. Please 
+<a href="http://kbase.us/contact-us">contact us</a> to be added to the developer list.
 
 
 ## <A NAME="steps"></A>Steps in Using SDK

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There are still some general restrictions on functionality that will gradually b
 
 If you have a tool you would like to register with KBase that cannot meet these requirements, please <a href="http://kbase.us/contact-us">contact us</a> to discuss possible solutions.
 
-You can use the SDK to develop and test Apps with a regular KBase user account (and a Git repository). When you’d like us to deploy your App publicly in KBase, please <a href="http://kbase.us/contact-us">contact us</a>  to be added to the developer list.
+You can use the SDK to develop and locally test Apps with a regular KBase user account (and a Git repository). However in order to deploy your app into a narrative you will need to <a href="http://kbase.us/contact-us">contact us</a>  to be added to the developer list.
 
 
 ## <A NAME="steps"></A>Steps in Using SDK

--- a/doc/kb_sdk_complete_module_info.md
+++ b/doc/kb_sdk_complete_module_info.md
@@ -1,7 +1,7 @@
 # <A NAME="top"></A>![alt text](https://avatars2.githubusercontent.com/u/1263946?v=3&s=84 "KBase") [KBase SDK](../README.md)
 
 1. [Install SDK Dependencies](kb_sdk_dependencies.md)
-2. [Install and Build SDK](kb_sdk_install_and_build.md)
+2. [Install SDK with Docker](kb_sdk_dockerized_install.md)
 3. [Create Module](kb_sdk_create_module.md)
 4. [Edit Module and Method(s)](kb_sdk_edit_module.md)
 5. [Locally Test Module and Method(s)](kb_sdk_local_test_module.md)

--- a/doc/kb_sdk_create_module.md
+++ b/doc/kb_sdk_create_module.md
@@ -1,7 +1,7 @@
 # <A NAME="top"></A>![alt text](https://avatars2.githubusercontent.com/u/1263946?v=3&s=84 "KBase") [KBase SDK](../README.md)
 
 1. [Install SDK Dependencies](kb_sdk_dependencies.md)
-2. [Install and Build SDK](kb_sdk_install_and_build.md)
+2. [Install SDK with Docker](kb_sdk_dockerized_install.md)
 3. **Create Module**
 4. [Edit Module and Method(s)](kb_sdk_edit_module.md)
 5. [Locally Test Module and Method(s)](kb_sdk_local_test_module.md)

--- a/doc/kb_sdk_dependencies.md
+++ b/doc/kb_sdk_dependencies.md
@@ -1,7 +1,7 @@
 # <A NAME="top"></A>![alt text](https://avatars2.githubusercontent.com/u/1263946?v=3&s=84 "KBase") [KBase SDK](../README.md)
 
 1. **Install SDK Dependencies**
-2. [Install and Build SDK](kb_sdk_install_and_build.md)
+2. [Install SDK with Docker](kb_sdk_dockerized_install.md)
 3. [Create Module](kb_sdk_create_module.md)
 4. [Edit Module and Method(s)](kb_sdk_edit_module.md)
 5. [Locally Test Module and Method(s)](kb_sdk_local_test_module.md)
@@ -21,32 +21,8 @@ System Dependencies:
 - Docker https://www.docker.com (for local testing)
 - At least 20 GB free on your hard drive to install Docker, Xcode, Java JRE, etc.
 
-(If you plan to build from source)
-- Java JDK 7+ http://www.oracle.com/technetwork/java/javase/downloads/index.html
-- JAVA_HOME environment variable set to JDK installation path
-- Apache Ant http://ant.apache.org
-
 #### Mac OS X 10.8+ or Linux
 Windows development is not currently supported.  If you are running Windows or do not want to develop on your local machine, we recommend using [VirtualBox](https://www.virtualbox.org) and installing Ubuntu 14+.
-
-#### Java JDK 7+  (No longer required if you are using the Docker-based installation)
-http://www.oracle.com/technetwork/java/javase/downloads/index.html
-
-After downloading and installing the JDK, set your `JAVA_HOME` environment variable to point to your JDK installation.  If you're not sure where that is, on a Mac the command `/usr/libexec/java_home` should tell you and on Linux `readlink -f $(which javac)` will provide the installed location of the javac, which you can use to find the base directory of the installation.  On a Mac you can set the variable like so:
-
-    # for bash
-    export JAVA_HOME=`/usr/libexec/java_home`
-    # for tcsh/csh
-    setenv JAVA_HOME `/usr/libexec/java_home`  
-    
-You should probably add this command to the end of your `~/.bash_profile` or ~/.bashrc file so it is always set when you start a terminal.
-
-#### Apache Ant (Only required for building the SDK tools from source)
-http://ant.apache.org
-
-http://ant.apache.org/manual/install.html
-
-The easist way to install Ant on a Mac is probably to use a package manager like [HomeBrew](http://brew.sh/), which allows to install simply by `brew install ant`.  Make sure that Ant install location is added to your PATH environment variable, which is generally handled for you if you use a package manager like HomeBrew.
 
 #### (Mac only) Xcode
 https://developer.apple.com/xcode

--- a/doc/kb_sdk_deploy.md
+++ b/doc/kb_sdk_deploy.md
@@ -1,7 +1,7 @@
 # <A NAME="top"></a>![alt text](https://avatars2.githubusercontent.com/u/1263946?v=3&s=84 "KBase") [KBase SDK](../README.md)
 
 1. [Install SDK Dependencies](kb_sdk_dependencies.md)
-2. [Install and Build SDK](kb_sdk_install_and_build.md)
+2. [Install SDK with Docker](kb_sdk_dockerized_install.md)
 3. [Create Module](kb_sdk_create_module.md)
 4. [Edit Module and Method(s)](kb_sdk_edit_module.md)
 5. [Locally Test Module and Method(s)](kb_sdk_local_test_module.md)

--- a/doc/kb_sdk_dockerized_install.md
+++ b/doc/kb_sdk_dockerized_install.md
@@ -54,5 +54,8 @@ The Image is fairly large, so this will take some time to download.  This step i
 should only be reqired during the initial installation.  However, KBsae staff may occasionally require the base image
 to be updated in order to match any changes in the base image running in the production KBase platform.
 
+#### Build from source
+While the preceding steps are the recommended approach, it's also possible to [build the SDK from source](kb_sdk_install_and_build.md)
+
 [\[Back to top\]](#top)<br>
 [\[Back to steps\]](../README.md#steps)

--- a/doc/kb_sdk_edit_module.md
+++ b/doc/kb_sdk_edit_module.md
@@ -1,7 +1,7 @@
 # <A NAME="top"></A>![alt text](https://avatars2.githubusercontent.com/u/1263946?v=3&s=84 "KBase") [KBase SDK](../README.md)
 
 1. [Install SDK Dependencies](kb_sdk_dependencies.md)
-2. [Install and Build SDK](kb_sdk_install_and_build.md)
+2. [Install SDK with Docker](kb_sdk_dockerized_install.md)
 3. [Create Module](kb_sdk_create_module.md)
 4. **Edit Module and Method(s)**
 5. [Locally Test Module and Method(s)](kb_sdk_local_test_module.md)

--- a/doc/kb_sdk_install_and_build.md
+++ b/doc/kb_sdk_install_and_build.md
@@ -10,8 +10,31 @@
 8. [Complete Module Info](kb_sdk_complete_module_info.md)
 9. [Deploy](kb_sdk_deploy.md)
 
+**Note: The recommended installation option is to run the [SDK as a Docker container.](kb_sdk_dockerized_install.md)**
 
 ### 2. Install and Build SDK
+
+#### Install additional dependencies
+
+##### Java JDK 7+
+http://www.oracle.com/technetwork/java/javase/downloads/index.html
+
+After downloading and installing the JDK, set your `JAVA_HOME` environment variable to point to your JDK installation.  If you're not sure where that is, on a Mac the command `/usr/libexec/java_home` should tell you and on Linux `readlink -f $(which javac)` will provide the installed location of the javac, which you can use to find the base directory of the installation.  On a Mac you can set the variable like so:
+
+    # for bash
+    export JAVA_HOME=`/usr/libexec/java_home`
+    # for tcsh/csh
+    setenv JAVA_HOME `/usr/libexec/java_home`  
+    
+You should probably add this command to the end of your `~/.bash_profile` or ~/.bashrc file so it is always set when you start a terminal.
+
+##### Apache Ant
+http://ant.apache.org
+
+http://ant.apache.org/manual/install.html
+
+The easist way to install Ant on a Mac is probably to use a package manager like [HomeBrew](http://brew.sh/), which allows to install simply by `brew install ant`.  Make sure that Ant install location is added to your PATH environment variable, which is generally handled for you if you use a package manager like HomeBrew.
+
 
 #### Fetch the code from GitHub:
 

--- a/doc/kb_sdk_local_test_module.md
+++ b/doc/kb_sdk_local_test_module.md
@@ -1,7 +1,7 @@
 # <A NAME="top"></A>![alt text](https://avatars2.githubusercontent.com/u/1263946?v=3&s=84 "KBase") [KBase SDK](../README.md)
 
 1. [Install SDK Dependencies](kb_sdk_dependencies.md)
-2. [Install and Build SDK](kb_sdk_install_and_build.md)
+2. [Install SDK with Docker](kb_sdk_dockerized_install.md)
 3. [Create Module](kb_sdk_create_module.md)
 4. [Edit Module and Method(s)](kb_sdk_edit_module.md)
 5. **Locally Test Module and Method(s)**

--- a/doc/kb_sdk_local_test_module.md
+++ b/doc/kb_sdk_local_test_module.md
@@ -63,15 +63,6 @@ Final Note: Docker will rebuild everything from the first detected change in a d
 
 If you have already been approved as a KBase developer. A token may be generated from your [kbase account profile](https://narrative.kbase.us/#auth2/account) under the Developer Tokens tab.
 
-**But you haven't approved my developer request and I _really_ want to test!**
-
-You can use the use the narrative to generate a shorter term authentication token. Open a [Narrative](https://narrative.kbase.us/#dashboard) and open a code cell(that's the blue cursor icon in the lower right hand of the screen). Type the following lines and hit SHIFT+Enter
-```
-import os
-os.environ['KB_AUTH_TOKEN']
-```
-You will still need to <a href="http://kbase.us/contact-us">contact us</a> to be added to the developer list in order to register your app.
-
 #### <A NAME="build-tests"></A>5C. Build tests of your methods
 
 Edit the local test config file (`test_local/test.cfg`) with a KBase user account name and token (note that this directory is in .gitignore so will not be copied to github.  You're safe!):

--- a/doc/kb_sdk_local_test_module.md
+++ b/doc/kb_sdk_local_test_module.md
@@ -63,6 +63,14 @@ Final Note: Docker will rebuild everything from the first detected change in a d
 
 If you have already been approved as a KBase developer. A token may be generated from your [kbase account profile](https://narrative.kbase.us/#auth2/account) under the Developer Tokens tab.
 
+**But you haven't approved my developer request and I _really_ want to test!**
+
+You can use the use the narrative to generate a shorter term authentication token. Open a [Narrative](https://narrative.kbase.us/#dashboard) and open a code cell(that's the blue cursor icon in the lower right hand of the screen). Type the following lines and hit SHIFT+Enter
+```
+import os
+os.environ['KB_AUTH_TOKEN']
+```
+You will still need to <a href="http://kbase.us/contact-us">contact us</a> to be added to the developer list in order to register your app.
 
 #### <A NAME="build-tests"></A>5C. Build tests of your methods
 

--- a/doc/kb_sdk_local_test_module.md
+++ b/doc/kb_sdk_local_test_module.md
@@ -57,17 +57,16 @@ RUN rm -rf tarball.tgz
 
 because the latter does not remove the previous bloating layers, despite the "rm" command.
 
-Final Note: Docker will rebuild everything from the first detected change in a dockerfile but pull everything upstream of that from cache. This means that if you are pulling in external data using RUN and a command like `git clone` or `wget` changes in those sources will not automatically be reflected in a rebuilt docker image unless the docker file changes at or before that import
+Final Note: Docker will rebuild everything from the first detected change in a dockerfile but pull everything upstream of that from cache. This means that if you are pulling in external data using RUN and a command like `git clone` or `wget` changes in those sources will not automatically be reflected in a rebuilt docker image unless the docker file changes at or before that import.
 
 #### <A NAME="get-token"></A>5B. Get a developer token
 
-If you have already been approved as a KBase developer. A token may be generated from your [kbase account profile](https://narrative.kbase.us/#auth2/account) under the Developer Tokens tab.
+If you have already been approved as a KBase developer, a token may be generated from your [kbase account profile](https://narrative.kbase.us/#auth2/account) under the Developer Tokens tab.
 
 #### <A NAME="build-tests"></A>5C. Build tests of your methods
 
-Edit the local test config file (`test_local/test.cfg`) with a KBase user account name and token (note that this directory is in .gitignore so will not be copied to github.  You're safe!):
+Edit the local test config file (`test_local/test.cfg`) with a developer token (note that this directory is in .gitignore so will not be copied to github.  You're safe!):
 
-    test_user = TEST_USER_NAME
     test_token = TEST_TOKEN
 
 *In the Docker shell*, run tests:

--- a/doc/kb_sdk_local_test_module.md
+++ b/doc/kb_sdk_local_test_module.md
@@ -56,29 +56,20 @@ RUN rm -rf tarball.tgz
 ```
 
 because the latter does not remove the previous bloating layers, despite the "rm" command.
-<!--
-    RUN git clone https://github.com/torognes/vsearch
-    WORKDIR vsearch
-    RUN ./configure 
-    RUN make
-    RUN make install
-    WORKDIR ../
 
-You will also need to add your KBase SDK module, and any necessary data, to the Dockerfile.  For example:
+Final Note: Docker will rebuild everything from the first detected change in a dockerfile but pull everything upstream of that from cache. This means that if you are pulling in external data using RUN and a command like `git clone` or `wget` changes in those sources will not automatically be reflected in a rebuilt docker image unless the docker file changes at or before that import
 
-    RUN mkdir -p /kb/module/test
-    WORKDIR test
-    RUN git clone https://github.com/dcchivian/kb_vsearch
-    RUN git clone https://github.com/dcchivian/kb_vsearch_test_data
-    WORKDIR ../
--->
+#### <A NAME="get-token"></A>5B. Get a developer token
 
-#### <A NAME="build-tests"></A>5B. Build tests of your methods
+If you have already been approved as a KBase developer. A token may be generated from your [kbase account profile](https://narrative.kbase.us/#auth2/account) under the Developer Tokens tab.
 
-Edit the local test config file (`test_local/test.cfg`) with a KBase user account name and password (note that this directory is in .gitignore so will not be copied to github.  You're safe!):
+
+#### <A NAME="build-tests"></A>5C. Build tests of your methods
+
+Edit the local test config file (`test_local/test.cfg`) with a KBase user account name and token (note that this directory is in .gitignore so will not be copied to github.  You're safe!):
 
     test_user = TEST_USER_NAME
-    test_password = TEST_PASSWORD
+    test_token = TEST_TOKEN
 
 *In the Docker shell*, run tests:
 

--- a/doc/kb_sdk_register_module.md
+++ b/doc/kb_sdk_register_module.md
@@ -1,7 +1,7 @@
 # <A NAME="top"></A>![alt text](https://avatars2.githubusercontent.com/u/1263946?v=3&s=84 "KBase") [KBase SDK](../README.md)
 
 1. [Install SDK Dependencies](kb_sdk_dependencies.md)
-2. [Install and Build SDK](kb_sdk_install_and_build.md)
+2. [Install SDK with Docker](kb_sdk_dockerized_install.md)
 3. [Create Module](kb_sdk_create_module.md)
 4. [Edit Module and Method(s)](kb_sdk_edit_module.md)
 5. [Locally Test Module and Method(s)](kb_sdk_local_test_module.md)

--- a/doc/kb_sdk_test_in_kbase.md
+++ b/doc/kb_sdk_test_in_kbase.md
@@ -1,7 +1,7 @@
 # <A NAME="top"></A>![alt text](https://avatars2.githubusercontent.com/u/1263946?v=3&s=84 "KBase") [KBase SDK](../README.md)
 
 1. [Install SDK Dependencies](kb_sdk_dependencies.md)
-2. [Install and Build SDK](kb_sdk_install_and_build.md)
+2. [Install SDK with Docker](kb_sdk_dockerized_install.md)
 3. [Create Module](kb_sdk_create_module.md)
 4. [Edit Module and Method(s)](kb_sdk_edit_module.md)
 5. [Locally Test Module and Method(s)](kb_sdk_local_test_module.md)

--- a/src/java/us/kbase/common/executionengine/CallbackServer.java
+++ b/src/java/us/kbase/common/executionengine/CallbackServer.java
@@ -35,6 +35,7 @@ import com.google.common.cache.CacheBuilder;
 
 import us.kbase.auth.AuthException;
 import us.kbase.auth.AuthToken;
+import us.kbase.auth.ConfigurableAuthService;
 import us.kbase.common.executionengine.CallbackServerConfigBuilder.CallbackServerConfig;
 import us.kbase.common.service.JacksonTupleModule;
 import us.kbase.common.service.JsonClientException;
@@ -108,6 +109,24 @@ public abstract class CallbackServer extends JsonServerServlet {
          * Might want to increase the cache lifetime or have a separate
          * cache for jobs that are done but haven't been checked by the user
          */
+    }
+    
+    @Override
+    public void startupFailed() {
+        /* This is a hack to avoid startup failures when the auth service isn't contactable.
+         * Since the callback server currently never contacts the auth service, and startupFailed()
+         * is only called when the auth client setup fails, it's safe to ignore. The callback
+         * server needs to be reworked to properly authenticate tokens in the longterm, see
+         * https://kbase-jira.atlassian.net/browse/TASK-881
+         */
+    }
+    
+    @Override
+    protected ConfigurableAuthService getAuth(final Map<String, String> config) {
+        /* see comments for startupFailed() above. Auth isn't needed, so we can skip trying to
+         * contact the auth server.
+         */
+        return null;
     }
     
     @Override

--- a/src/java/us/kbase/kidl/KidlParser.java
+++ b/src/java/us/kbase/kidl/KidlParser.java
@@ -4,22 +4,13 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
-
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.xml.sax.SAXException;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;

--- a/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
+++ b/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
@@ -233,7 +233,8 @@ public class DockerClientServerTester {
     }
     
     protected static void testClients(File moduleDir, String clientEndpointUrl,
-            boolean async, boolean dynamic, String serverType) throws Exception { 
+            boolean async, boolean dynamic, String serverType) throws Exception {
+        TypeGeneratorTest.ensureCasperJsInstalled();
         String moduleName = moduleDir.getName();
         File specFile = new File(moduleDir, moduleName + ".spec");
         ClientInstaller clInst = new ClientInstaller(moduleDir, true);
@@ -392,10 +393,6 @@ public class DockerClientServerTester {
             Assert.assertEquals("Perl client exit code should be 0", 0, exitCode);
         }
         // JavaScript
-        if (!TypeGeneratorTest.isCasperJsInstalled()) {
-            System.err.println("- JavaScript client tests are skipped");
-            return;
-        }
         System.out.print("JavaScript client -> " + serverType + " server ");
         clInst.install("javascript", async, false, dynamic, "dev", false, 
                 specFile.getCanonicalPath(), "lib2");
@@ -428,6 +425,7 @@ public class DockerClientServerTester {
 
     protected static void testStatus(File moduleDir, String clientEndpointUrl,
             boolean async, boolean dynamic, String serverType) throws Exception {
+        TypeGeneratorTest.ensureCasperJsInstalled();
         String moduleName = moduleDir.getName();
         File specFile = new File(moduleDir, moduleName + ".spec");
         // Java client
@@ -558,14 +556,12 @@ public class DockerClientServerTester {
             }
         }
         // JavaScript
-        if (!TypeGeneratorTest.isCasperJsInstalled()) {
-            System.err.println("- JavaScript client tests are skipped");
-            return;
-        }
-        if (outputFile.exists())
+        if (outputFile.exists()) {
             outputFile.delete();
-        if (errorFile.exists())
+        }
+        if (errorFile.exists()) {
             errorFile.delete();
+        }
         System.out.println("JavaScript client (status) -> " + serverType + " server");
         clInst.install("javascript", async, false, dynamic, "dev", false, 
                 specFile.getCanonicalPath(), "lib2");

--- a/src/java/us/kbase/mobu/initializer/test/ExecEngineMock.java
+++ b/src/java/us/kbase/mobu/initializer/test/ExecEngineMock.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 
-import us.kbase.auth.AuthService;
 import us.kbase.auth.AuthToken;
 import us.kbase.common.service.JacksonTupleModule;
 import us.kbase.common.service.JsonServerMethod;

--- a/src/java/us/kbase/mobu/runner/ModuleRunner.java
+++ b/src/java/us/kbase/mobu/runner/ModuleRunner.java
@@ -195,6 +195,7 @@ public class ModuleRunner {
         rpc.put("context", new LinkedHashMap<String, Object>());
         UObject.getMapper().writeValue(new File(workDir, "input.json"), rpc);
         ////////////////////////////////// Starting callback service //////////////////////////////
+        System.out.println("Info: getting callback url...");
         int callbackPort = NetUtils.findFreePort();
         URL callbackUrl = CallbackServer.getCallbackUrl(callbackPort, callbackNetworks);
         Server jettyServer = null;
@@ -239,12 +240,9 @@ public class ModuleRunner {
             context.addServlet(new ServletHolder(catalogSrv),"/*");
             jettyServer.start();
         } else {
-            if (callbackNetworks != null && callbackNetworks.length > 0) {
-                throw new IllegalStateException("No proper callback IP was found, " +
-                        "please check callback_networks parameter in configuration");
-            }
-            System.out.println("WARNING: No callback URL was received " +
-                    "by the job runner. Local callbacks are disabled.");
+            throw new IllegalStateException("No callback URL was received " +
+                    "by the job runner. Local callbacks are disabled. " +
+                    "CallbackNetworks: "+Arrays.toString(callbackNetworks));
         }
         ////////////////////////////////// Running Docker /////////////////////////////////////////
         final String containerName = "local_" + moduleName.toLowerCase() + "_" + 

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -178,9 +178,6 @@ public class ModuleTester {
         System.out.println("Info: getting callback url...");
         URL callbackUrl = CallbackServer.getCallbackUrl(callbackPort, callbackNetworks);
         Server jettyServer = null;
-        //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-        callbackUrl = null;
-        //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
         if (callbackUrl != null) {
             if( System.getProperty("os.name").startsWith("Windows") ) {
                 JsonServerSyslog.setStaticUseSyslog(false);

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -214,7 +214,8 @@ public class ModuleTester {
             jettyServer.start();
         } else {
             throw new IllegalStateException("No callback URL was received " +
-                    "by the job runner. Local callbacks are disabled. CallbackNetworks: "+callbackNetworks);
+                    "by the job runner. Local callbacks are disabled. " +
+                    "CallbackNetworks: "+Arrays.toString(callbackNetworks));
         }
         ///////////////////////////////////////////////////////////////////////////////////////////
         try {

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -175,8 +175,13 @@ public class ModuleTester {
             System.out.println("Custom network instarface list is defined: " + 
                     Arrays.asList(callbackNetworks));
         }
+        System.out.println("Info: getting callback url...");
         URL callbackUrl = CallbackServer.getCallbackUrl(callbackPort, callbackNetworks);
         Server jettyServer = null;
+        //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+        System.out.println("Hacking callback url...");
+        callbackUrl = null;
+        //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
         if (callbackUrl != null) {
             if( System.getProperty("os.name").startsWith("Windows") ) {
                 JsonServerSyslog.setStaticUseSyslog(false);
@@ -212,12 +217,8 @@ public class ModuleTester {
             context.addServlet(new ServletHolder(catalogSrv),"/*");
             jettyServer.start();
         } else {
-            if (callbackNetworks != null && callbackNetworks.length > 0) {
-                throw new IllegalStateException("No proper callback IP was found, " +
-                		"please check callback_networks parameter in test.cfg");
-            }
-            System.out.println("WARNING: No callback URL was received " +
-                    "by the job runner. Local callbacks are disabled.");
+            throw new IllegalStateException("ERROR: No callback URL was received " +
+                    "by the job runner. Local callbacks are disabled. CallbackNetworks: "+callbackNetworksText);
         }
         ///////////////////////////////////////////////////////////////////////////////////////////
         try {

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -178,6 +178,9 @@ public class ModuleTester {
         System.out.println("Info: getting callback url...");
         URL callbackUrl = CallbackServer.getCallbackUrl(callbackPort, callbackNetworks);
         Server jettyServer = null;
+        //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+        callbackUrl = null;
+        //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
         if (callbackUrl != null) {
             if( System.getProperty("os.name").startsWith("Windows") ) {
                 JsonServerSyslog.setStaticUseSyslog(false);

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -178,10 +178,6 @@ public class ModuleTester {
         System.out.println("Info: getting callback url...");
         URL callbackUrl = CallbackServer.getCallbackUrl(callbackPort, callbackNetworks);
         Server jettyServer = null;
-        //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-        System.out.println("Hacking callback url...");
-        callbackUrl = null;
-        //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
         if (callbackUrl != null) {
             if( System.getProperty("os.name").startsWith("Windows") ) {
                 JsonServerSyslog.setStaticUseSyslog(false);
@@ -217,7 +213,7 @@ public class ModuleTester {
             context.addServlet(new ServletHolder(catalogSrv),"/*");
             jettyServer.start();
         } else {
-            throw new IllegalStateException("ERROR: No callback URL was received " +
+            throw new IllegalStateException("No callback URL was received " +
                     "by the job runner. Local callbacks are disabled. CallbackNetworks: "+callbackNetworksText);
         }
         ///////////////////////////////////////////////////////////////////////////////////////////

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -214,7 +214,7 @@ public class ModuleTester {
             jettyServer.start();
         } else {
             throw new IllegalStateException("No callback URL was received " +
-                    "by the job runner. Local callbacks are disabled. CallbackNetworks: "+callbackNetworksText);
+                    "by the job runner. Local callbacks are disabled. CallbackNetworks: "+callbackNetworks);
         }
         ///////////////////////////////////////////////////////////////////////////////////////////
         try {

--- a/src/java/us/kbase/mobu/tester/test/CallbackServerTest.java
+++ b/src/java/us/kbase/mobu/tester/test/CallbackServerTest.java
@@ -570,7 +570,7 @@ public class CallbackServerTest {
         String moduleName = "njs_sdk_test_2";
         String methodName = "run";
         String release = "dev";
-        String ver = "0.0.8";
+        String ver = "0.0.9";
         Map<String, Object> methparams = new HashMap<String, Object>();
         methparams.put("id", "myid");
         Map<String, Object> results = res.callMethod(
@@ -605,7 +605,7 @@ public class CallbackServerTest {
         String methodName = "run";
         String release = "dev";
         String ver = "0.0.3";
-        String commit1 = "de445aa9c3404d68be3a87b03c1dbf2f3fccba24";
+        String commit1 = "03b9210ac825858c1ae6339786686cea5dac5929";
         final ModuleRunVersion runver = new ModuleRunVersion(
                 new URL("https://github.com/kbasetest/njs_sdk_test_1"),
                 new ModuleMethod(moduleName + "." + methodName),
@@ -618,7 +618,7 @@ public class CallbackServerTest {
         final CallbackStuff res = startCallBackServer(runver, params, wsobjs);
         System.out.println("Running multiCallProvenance in dir " + res.tempdir);
         String moduleName2 = "njs_sdk_test_2";
-        String commit2 = "3cd0ed213d8376349bdb0f454c5f5bc8b31ea650";
+        String commit2 = "284948a93524ba51e48b1c71693b269647c125c3";
         @SuppressWarnings("unchecked")
         Map<String, Object> methparams = UObject.transformStringToObject(
                 String.format(

--- a/src/java/us/kbase/mobu/tester/test/ModuleTesterFailHardTest.java
+++ b/src/java/us/kbase/mobu/tester/test/ModuleTesterFailHardTest.java
@@ -1,0 +1,120 @@
+package us.kbase.mobu.tester.test;
+
+import org.apache.commons.io.FileUtils;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import us.kbase.auth.AuthToken;
+import us.kbase.common.executionengine.CallbackServer;
+import us.kbase.mobu.ModuleBuilder;
+import us.kbase.mobu.initializer.ModuleInitializer;
+import us.kbase.mobu.initializer.test.DockerClientServerTester;
+import us.kbase.mobu.tester.ModuleTester;
+import us.kbase.scripts.test.TestConfigHelper;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/** This class tests to ensure that the unit test run fails hard if the callback
+ *  server cannot be instantiated.
+ *
+ */
+@PowerMockIgnore({"javax.net.ssl.*"})   // PowerMockRunner tries to classload a different set of net classes
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( CallbackServer.class )
+public class ModuleTesterFailHardTest {
+    private static final String SIMPLE_MODULE_NAME = "ASimpleModule_for_unit_testing";
+    private static final boolean cleanupAfterTests = true;
+    private static List<String> createdModuleNames = new ArrayList<String>();
+    private static AuthToken token;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        token = TestConfigHelper.getToken();
+        PowerMockito.mockStatic(CallbackServer.class);
+        // force function to always return null
+        when(CallbackServer.getCallbackUrl(anyInt(),any(String[].class))).thenReturn(null);
+        Assert.assertNull(CallbackServer.getCallbackUrl(0, new String[1]));
+    }
+
+    @AfterClass
+    public static void tearDownModule() throws Exception {
+        if (cleanupAfterTests)
+            for (String moduleName : createdModuleNames)
+                try {
+                    deleteDir(moduleName);
+                } catch (Exception ex) {
+                    System.err.println("Error cleaning up module [" +
+                            moduleName + "]: " + ex.getMessage());
+                }
+    }
+
+    @After
+    public void afterText() {
+        System.out.println();
+    }
+
+    private static void deleteDir(String moduleName) throws Exception {
+        File module = new File(moduleName);
+        if (module.exists() && module.isDirectory())
+            FileUtils.deleteDirectory(module);
+    }
+
+    private void init(String lang, String moduleName) throws Exception {
+        deleteDir(moduleName);
+        createdModuleNames.add(moduleName);
+        ModuleInitializer initer = new ModuleInitializer(moduleName, token.getUserName(),
+                lang, false);
+        initer.initialize(true);
+    }
+
+    private int runTestsInDocker(String moduleName) throws Exception {
+        File moduleDir = new File(moduleName);
+        return runTestsInDocker(moduleDir, token);
+    }
+
+    public static int runTestsInDocker(File moduleDir, AuthToken token) throws Exception {
+        return runTestsInDocker(moduleDir, token, false);
+    }
+
+    public static int runTestsInDocker(File moduleDir, AuthToken token,
+                                       boolean skipValidation) throws Exception {
+        DockerClientServerTester.correctDockerfile(moduleDir);
+        File testCfgFile = new File(moduleDir, "test_local/test.cfg");
+        String testCfgText = ""+
+                "test_token=" + token.getToken() + "\n" +
+                "kbase_endpoint=" + TestConfigHelper.getKBaseEndpoint() + "\n" +
+                "auth_service_url=" + TestConfigHelper.getAuthServiceUrl() + "\n" +
+                "auth_service_url_allow_insecure=" +
+                TestConfigHelper.getAuthServiceUrlInsecure() + "\n";
+        FileUtils.writeStringToFile(testCfgFile, testCfgText);
+        int exitCode = new ModuleTester(moduleDir).runTests(ModuleBuilder.DEFAULT_METHOD_STORE_URL,
+                skipValidation, false);
+        System.out.println("Exit code: " + exitCode);
+        return exitCode;
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testPythonModuleExample() throws Exception {
+        System.out.println("Test [testPythonModuleExample]");
+        String lang = "python";
+        String moduleName = SIMPLE_MODULE_NAME + "Python";
+        init(lang, moduleName);
+        int exitCode = runTestsInDocker(moduleName);
+    }
+}

--- a/src/java/us/kbase/mobu/tester/test/ModuleTesterTest.java
+++ b/src/java/us/kbase/mobu/tester/test/ModuleTesterTest.java
@@ -71,24 +71,27 @@ public class ModuleTesterTest {
 	public static int runTestsInDocker(File moduleDir, AuthToken token) throws Exception {
 	    return runTestsInDocker(moduleDir, token, false);
 	}
-
-	public static int runTestsInDocker(File moduleDir, AuthToken token, 
-	        boolean skipValidation) throws Exception {
-	    DockerClientServerTester.correctDockerfile(moduleDir);
-	    File testCfgFile = new File(moduleDir, "test_local/test.cfg");
+    
+    public static int runTestsInDocker(
+            final File moduleDir,
+            final AuthToken token, 
+            final boolean skipValidation)
+            throws Exception {
+        DockerClientServerTester.correctDockerfile(moduleDir);
+        File testCfgFile = new File(moduleDir, "test_local/test.cfg");
         String testCfgText = ""+
                 "test_token=" + token.getToken() + "\n" +
                 "kbase_endpoint=" + TestConfigHelper.getKBaseEndpoint() + "\n" +
                 "auth_service_url=" + TestConfigHelper.getAuthServiceUrl() + "\n" +
                 "auth_service_url_allow_insecure=" + 
-                TestConfigHelper.getAuthServiceUrlInsecure() + "\n";
+                    TestConfigHelper.getAuthServiceUrlInsecure() + "\n";
         FileUtils.writeStringToFile(testCfgFile, testCfgText);
         int exitCode = new ModuleTester(moduleDir).runTests(ModuleBuilder.DEFAULT_METHOD_STORE_URL,
-	            skipValidation, false);
-	    System.out.println("Exit code: " + exitCode);
-	    return exitCode;
-	}
-	
+                skipValidation, false);
+        System.out.println("Exit code: " + exitCode);
+        return exitCode;
+    }
+
 	@Test
 	public void testPerlModuleExample() throws Exception {
 	    System.out.println("Test [testPerlModuleExample]");

--- a/src/java/us/kbase/templates/module_readme_test_local.vm.properties
+++ b/src/java/us/kbase/templates/module_readme_test_local.vm.properties
@@ -4,5 +4,5 @@ supposed to be commited into git repo or to be copied inside Docker
 image.
 
 To run tests:
-- change test_user and test_password in test.cfg file
+- add a valid test_token to test.cfg file
 - run "kb-sdk test"

--- a/src/java/us/kbase/templates/module_test_cfg.vm.properties
+++ b/src/java/us/kbase/templates/module_test_cfg.vm.properties
@@ -1,12 +1,10 @@
 # PLEASE DO NOT COMMIT THIS FILE INTO GIT REPO !!!
-# Set credentials of your KBase account. If you don't have one, 
-# please visit http://kbase.us/sign-up-for-a-kbase-account/
-# You can leave "test_password" field empty. You will be asked
-# to enter your password every time you run tests in this case.
-# WARNING: parameters 'test_user' and 'test_password' will be
-# retired soon. Please use 'test_token' instead.
-test_user=
-test_password=
+# Add a test_token from  your KBase developer account.
+# Tokens may be generated under the developer tab:
+# https://narrative.kbase.us/#auth2/account. If you don't have
+# a developer account, please contact us to request one:
+# http://kbase.us/contact-us/
+
 test_token=
 kbase_endpoint=https://appdev.kbase.us/services
 
@@ -20,10 +18,7 @@ kbase_endpoint=https://appdev.kbase.us/services
 #njsw_url=
 #catalog_url=
 
-# Old auth-service URL:
-#auth_service_url=https://kbase.us/services/authorization/Sessions/Login
-
-# New auth2-service URL:
+#auth2-service URL:
 auth_service_url=https://appdev.kbase.us/services/auth/api/legacy/KBase/Sessions/Login
 auth_service_url_allow_insecure=false
 

--- a/src/java/us/kbase/templates/module_test_java_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_java_client.vm.properties
@@ -173,7 +173,8 @@ public class ${java_module_name}ServerTest {
                 .withAssemblyInputRef("fake").withMinLength(10L), token, getContext());
             Assert.fail("Error is expected above");
         } catch (ServerException ex) {
-            Assert.assertEquals("Invalid workspace reference string! Found fake", ex.getMessage());
+            Assert.assertEquals("Error on ObjectSpecification #1: Illegal number of separators " +
+                    "/ in object reference fake", ex.getMessage());
         }
     }
 #else

--- a/src/java/us/kbase/templates/module_test_perl_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_perl_client.vm.properties
@@ -77,7 +77,7 @@ eval {
                                assembly_input_ref=>"fake",
                                min_length => 10});
     };
-    like($@, qr/Invalid workspace reference string! Found fake/);
+    like($@, qr#separators / in object reference fake#);
     
     eval { 
         $impl->filter_contigs({workspace_name => get_ws_name(),

--- a/test_dependencies.md
+++ b/test_dependencies.md
@@ -6,7 +6,7 @@ New versions of paramiko complain about being unable to import SSH2_AGENTC_REQUE
 
 With the new auth2 clients and server we may no longer need rsa, paramiko, Crypt::OpenSSL::RSA, Convert::PEM
 
-pip install nose2 jsonrpcbase rsa paramiko==1.10.2
+pip install requests nose2 jsonrpcbase rsa paramiko==1.10.2
 
 cpan Moose
 

--- a/test_dependencies.md
+++ b/test_dependencies.md
@@ -13,3 +13,5 @@ cpan Moose
 cpan -f -i RPC::Any
 
 cpan Parse::Yapp Devel::StackTrace Lingua::EN::Inflect Template File::Slurp Cwd JSON Data::UUID XML::Dumper JSON::RPC::Client Exception::Class Config::Simple Digest::SHA1 Crypt::OpenSSL::RSA Convert::PEM DateTime MIME::Base64 URI Object::Tiny::RW Plack File::ShareDir::Install YAML TAP::Harness Plack::Middleware::CrossOrigin RPC::Any::Server::JSONRPC::PSGI
+
+CasperJS must be installed, > 1.1.0. http://casperjs.org/

--- a/test_dependencies.md
+++ b/test_dependencies.md
@@ -12,6 +12,8 @@ cpan Moose
 
 cpan -f -i RPC::Any
 
+cpan Bio::KBase::Exceptions
+
 cpan Parse::Yapp Devel::StackTrace Lingua::EN::Inflect Template File::Slurp Cwd JSON Data::UUID XML::Dumper JSON::RPC::Client Exception::Class Config::Simple Digest::SHA1 Crypt::OpenSSL::RSA Convert::PEM DateTime MIME::Base64 URI Object::Tiny::RW Plack File::ShareDir::Install YAML TAP::Harness Plack::Middleware::CrossOrigin RPC::Any::Server::JSONRPC::PSGI
 
 CasperJS must be installed, > 1.1.0. http://casperjs.org/


### PR DESCRIPTION
- added a fix in ModuleTester and ModuleRunner
- added new jar dependencies for power mockito testing. Specifically for mocking the static method CallbackServer.getCallbackUrl()
- added a test for the failure case in ModuleTester using a mocked CallbackServer.getCallbackUrl()

Note: this PR is linked to corresponding PR in Jars repo containing new jar dependencies