### PR TITLE
Auth2 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ There are still some general restrictions on functionality that will gradually b
 
 If you have a tool you would like to register with KBase that cannot meet these requirements, please <a href="http://kbase.us/contact-us">contact us</a> to discuss possible solutions.
 
-You can use the SDK to develop and locally test Apps with a regular KBase user account (and a Git repository). However in order to deploy your app into a narrative you will need to <a href="http://kbase.us/contact-us">contact us</a>  to be added to the developer list.
+In order to use the SDK to test and deploy Apps you will need developer credentials. Please 
+<a href="http://kbase.us/contact-us">contact us</a> to be added to the developer list.
 
 
 ## <A NAME="steps"></A>Steps in Using SDK

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There are still some general restrictions on functionality that will gradually b
 
 If you have a tool you would like to register with KBase that cannot meet these requirements, please <a href="http://kbase.us/contact-us">contact us</a> to discuss possible solutions.
 
-You can use the SDK to develop and test Apps with a regular KBase user account (and a Git repository). When you’d like us to deploy your App publicly in KBase, please <a href="http://kbase.us/contact-us">contact us</a>  to be added to the developer list.
+You can use the SDK to develop and locally test Apps with a regular KBase user account (and a Git repository). However in order to deploy your app into a narrative you will need to <a href="http://kbase.us/contact-us">contact us</a>  to be added to the developer list.
 
 
 ## <A NAME="steps"></A>Steps in Using SDK

--- a/doc/kb_sdk_local_test_module.md
+++ b/doc/kb_sdk_local_test_module.md
@@ -63,15 +63,6 @@ Final Note: Docker will rebuild everything from the first detected change in a d
 
 If you have already been approved as a KBase developer. A token may be generated from your [kbase account profile](https://narrative.kbase.us/#auth2/account) under the Developer Tokens tab.
 
-**But you haven't approved my developer request and I _really_ want to test!**
-
-You can use the use the narrative to generate a shorter term authentication token. Open a [Narrative](https://narrative.kbase.us/#dashboard) and open a code cell(that's the blue cursor icon in the lower right hand of the screen). Type the following lines and hit SHIFT+Enter
-```
-import os
-os.environ['KB_AUTH_TOKEN']
-```
-You will still need to <a href="http://kbase.us/contact-us">contact us</a> to be added to the developer list in order to register your app.
-
 #### <A NAME="build-tests"></A>5C. Build tests of your methods
 
 Edit the local test config file (`test_local/test.cfg`) with a KBase user account name and token (note that this directory is in .gitignore so will not be copied to github.  You're safe!):

--- a/doc/kb_sdk_local_test_module.md
+++ b/doc/kb_sdk_local_test_module.md
@@ -63,6 +63,14 @@ Final Note: Docker will rebuild everything from the first detected change in a d
 
 If you have already been approved as a KBase developer. A token may be generated from your [kbase account profile](https://narrative.kbase.us/#auth2/account) under the Developer Tokens tab.
 
+**But you haven't approved my developer request and I _really_ want to test!**
+
+You can use the use the narrative to generate a shorter term authentication token. Open a [Narrative](https://narrative.kbase.us/#dashboard) and open a code cell(that's the blue cursor icon in the lower right hand of the screen). Type the following lines and hit SHIFT+Enter
+```
+import os
+os.environ['KB_AUTH_TOKEN']
+```
+You will still need to <a href="http://kbase.us/contact-us">contact us</a> to be added to the developer list in order to register your app.
 
 #### <A NAME="build-tests"></A>5C. Build tests of your methods
 

--- a/doc/kb_sdk_local_test_module.md
+++ b/doc/kb_sdk_local_test_module.md
@@ -57,17 +57,16 @@ RUN rm -rf tarball.tgz
 
 because the latter does not remove the previous bloating layers, despite the "rm" command.
 
-Final Note: Docker will rebuild everything from the first detected change in a dockerfile but pull everything upstream of that from cache. This means that if you are pulling in external data using RUN and a command like `git clone` or `wget` changes in those sources will not automatically be reflected in a rebuilt docker image unless the docker file changes at or before that import
+Final Note: Docker will rebuild everything from the first detected change in a dockerfile but pull everything upstream of that from cache. This means that if you are pulling in external data using RUN and a command like `git clone` or `wget` changes in those sources will not automatically be reflected in a rebuilt docker image unless the docker file changes at or before that import.
 
 #### <A NAME="get-token"></A>5B. Get a developer token
 
-If you have already been approved as a KBase developer. A token may be generated from your [kbase account profile](https://narrative.kbase.us/#auth2/account) under the Developer Tokens tab.
+If you have already been approved as a KBase developer, a token may be generated from your [kbase account profile](https://narrative.kbase.us/#auth2/account) under the Developer Tokens tab.
 
 #### <A NAME="build-tests"></A>5C. Build tests of your methods
 
-Edit the local test config file (`test_local/test.cfg`) with a KBase user account name and token (note that this directory is in .gitignore so will not be copied to github.  You're safe!):
+Edit the local test config file (`test_local/test.cfg`) with a developer token (note that this directory is in .gitignore so will not be copied to github.  You're safe!):
 
-    test_user = TEST_USER_NAME
     test_token = TEST_TOKEN
 
 *In the Docker shell*, run tests:

--- a/doc/kb_sdk_local_test_module.md
+++ b/doc/kb_sdk_local_test_module.md
@@ -56,29 +56,20 @@ RUN rm -rf tarball.tgz
 ```
 
 because the latter does not remove the previous bloating layers, despite the "rm" command.
-<!--
-    RUN git clone https://github.com/torognes/vsearch
-    WORKDIR vsearch
-    RUN ./configure 
-    RUN make
-    RUN make install
-    WORKDIR ../
 
-You will also need to add your KBase SDK module, and any necessary data, to the Dockerfile.  For example:
+Final Note: Docker will rebuild everything from the first detected change in a dockerfile but pull everything upstream of that from cache. This means that if you are pulling in external data using RUN and a command like `git clone` or `wget` changes in those sources will not automatically be reflected in a rebuilt docker image unless the docker file changes at or before that import
 
-    RUN mkdir -p /kb/module/test
-    WORKDIR test
-    RUN git clone https://github.com/dcchivian/kb_vsearch
-    RUN git clone https://github.com/dcchivian/kb_vsearch_test_data
-    WORKDIR ../
--->
+#### <A NAME="get-token"></A>5B. Get a developer token
 
-#### <A NAME="build-tests"></A>5B. Build tests of your methods
+If you have already been approved as a KBase developer. A token may be generated from your [kbase account profile](https://narrative.kbase.us/#auth2/account) under the Developer Tokens tab.
 
-Edit the local test config file (`test_local/test.cfg`) with a KBase user account name and password (note that this directory is in .gitignore so will not be copied to github.  You're safe!):
+
+#### <A NAME="build-tests"></A>5C. Build tests of your methods
+
+Edit the local test config file (`test_local/test.cfg`) with a KBase user account name and token (note that this directory is in .gitignore so will not be copied to github.  You're safe!):
 
     test_user = TEST_USER_NAME
-    test_password = TEST_PASSWORD
+    test_token = TEST_TOKEN
 
 *In the Docker shell*, run tests:
 

--- a/src/java/us/kbase/templates/module_readme_test_local.vm.properties
+++ b/src/java/us/kbase/templates/module_readme_test_local.vm.properties
@@ -4,5 +4,5 @@ supposed to be commited into git repo or to be copied inside Docker
 image.
 
 To run tests:
-- change test_user and test_password in test.cfg file
+- add a valid test_token to test.cfg file
 - run "kb-sdk test"

--- a/src/java/us/kbase/templates/module_test_cfg.vm.properties
+++ b/src/java/us/kbase/templates/module_test_cfg.vm.properties
@@ -1,12 +1,10 @@
 # PLEASE DO NOT COMMIT THIS FILE INTO GIT REPO !!!
-# Set credentials of your KBase account. If you don't have one, 
-# please visit http://kbase.us/sign-up-for-a-kbase-account/
-# You can leave "test_password" field empty. You will be asked
-# to enter your password every time you run tests in this case.
-# WARNING: parameters 'test_user' and 'test_password' will be
-# retired soon. Please use 'test_token' instead.
-test_user=
-test_password=
+# Add a test_token from  your KBase developer account.
+# Tokens may be generated under the developer tab:
+# https://narrative.kbase.us/#auth2/account. If you don't have
+# a developer account, please contact us to request one:
+# http://kbase.us/contact-us/
+
 test_token=
 kbase_endpoint=https://appdev.kbase.us/services
 
@@ -20,10 +18,7 @@ kbase_endpoint=https://appdev.kbase.us/services
 #njsw_url=
 #catalog_url=
 
-# Old auth-service URL:
-#auth_service_url=https://kbase.us/services/authorization/Sessions/Login
-
-# New auth2-service URL:
+#auth2-service URL:
 auth_service_url=https://appdev.kbase.us/services/auth/api/legacy/KBase/Sessions/Login
 auth_service_url_allow_insecure=false
 


### PR DESCRIPTION
Primary updated the docs to discuss generation and use of a token rather than a password. If you think it's a bad idea for users to use a token from the narrative to be able to test, let me know and I'll rollback that commit.

Fixes PTV-306
https://kbase-jira.atlassian.net/browse/PTV-306