### PR TITLE
minor improvements to wording and formatting

### DIFF
--- a/doc/kb_sdk_dependencies.md
+++ b/doc/kb_sdk_dependencies.md
@@ -13,6 +13,8 @@
 11. [Deploy](kb_sdk_deploy.md)
 
 
+This document describes how to set up your computer to start using the KBase SDK. Please see the [SDK README](https://github.com/kbase/kb_sdk/blob/master/README.md) for general information about the SDK.
+
 ### 1. Install SDK Dependencies
 
 System Dependencies:
@@ -24,6 +26,7 @@ System Dependencies:
 - At least 20 GB free on your hard drive to install Docker, Xcode, Java JRE, etc.
 
 #### Mac OS X 10.8+ or Linux
+We recommend using Mac OS X 10.8+ or Linux for SDK development.
 Windows development is not currently supported.  If you are running Windows or do not want to develop on your local machine, we recommend using [VirtualBox](https://www.virtualbox.org) and installing Ubuntu 14+.
 
 #### (Mac only) Xcode
@@ -40,9 +43,9 @@ On a Mac this is typically already installed as part of Xcode.
 
 https://www.docker.com
 
-This is *highly* recommended for KBase module development and is required if you will use the Docker-based installation of the SDK tools.  KBase module code is run in KBase using Docker, which allows you to easily install all system tools and dependencies your module requires.  Installing Docker locally allows you to test your build and run tests on your own computer before registering your module with KBase which significantly accelerates development.
+This is *highly* recommended for KBase module development and is required if you will use the Docker-based installation of the SDK tools. KBase module code is run in KBase using Docker, which allows you to easily install all system tools and dependencies your module requires. Installing Docker locally allows you to test your build and run tests on your own computer before registering your module with KBase, significantly accelerating development.
 
-Docker Installation and Daemon starting Instructions:
+### Docker Installation and Daemon Starting
 
 https://www.docker.com/mac
 
@@ -50,10 +53,9 @@ https://www.docker.com/linux
 
 On Linux Docker is fairly easy to install, although note that the service runs as the root user. As such, all Docker commands require root permissions and any KB_SDK commands that interact with Docker (such as `make sdkbase`) will require root permissions. An alterative to this is to create a docker group for Docker users as described in the Docker installation instructions.
 
-Docker provides an installation for Mac that runs in a light-weight virtual machine but is integrated to provide a seam-less experience.  After installation, the
+Docker provides an installation for Mac that runs in a lightweight virtual machine but is integrated to provide a seamless experience.  After installation, the
 Docker CLI tools should be available from a terminal window.
 
 
 [\[Back to top\]](#top)<br>
 [\[Back to steps\]](../README.md#steps)
-

--- a/doc/kb_sdk_dependencies.md
+++ b/doc/kb_sdk_dependencies.md
@@ -45,11 +45,11 @@ https://www.docker.com
 
 This is *highly* recommended for KBase module development and is required if you will use the Docker-based installation of the SDK tools. KBase module code is run in KBase using Docker, which allows you to easily install all system tools and dependencies your module requires. Installing Docker locally allows you to test your build and run tests on your own computer before registering your module with KBase, significantly accelerating development.
 
-### Docker Installation and Daemon Starting
+### Docker Installation
 
-https://www.docker.com/mac
+Instructions for installing on Mac: https://www.docker.com/mac
 
-https://www.docker.com/linux
+Instructions for installing on Linux: https://www.docker.com/linux
 
 On Linux Docker is fairly easy to install, although note that the service runs as the root user. As such, all Docker commands require root permissions and any KB_SDK commands that interact with Docker (such as `make sdkbase`) will require root permissions. An alterative to this is to create a docker group for Docker users as described in the Docker installation instructions.
 


### PR DESCRIPTION
the last section is headed "Docker Installation and Daemon Starting" but it doesn't seem to have any instructions about starting a daemon. remove that phrase from header? @JamesJeffryes 