### PR TITLE
SCT-475 fix python build, tests, etc.

### DIFF
--- a/DeveloperNotes.md
+++ b/DeveloperNotes.md
@@ -1,0 +1,3 @@
+Regarding Java 9 incompatibility: https://blog.codefx.org/java/jsr-305-java-9/
+
+Specifically, the Generated annotation is a problem.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ There are still some general restrictions on functionality that will gradually b
 - Operates only on supported KBase data types
 - Uses existing data visualization widgets
 - Does not require new uploaders/downloaders
-- Wrapper written in Python, Java, R, or Perl
+- Wrapper written in Python, Java, or Perl
 
 In addition to these technical restrictions, tools in KBase are subject to a [review process](https://github.com/kbase/project_guides/blob/master/SDK_Guidelines.md) prior to public release. If you have a tool you would like to register with KBase that cannot meet these requirements, please <a href="http://kbase.us/contact-us">contact us</a> to discuss possible solutions.
 
@@ -55,7 +55,7 @@ For the adventurous, there is an experimental Dockerized installation that only 
 System Dependencies:
 
 - Mac OS X 10.8+ or Linux. kb-sdk does not run natively in Windows, but see [here](doc/FAQ.md#windows) for more details.
-- Java JRE 7+ http://www.oracle.com/technetwork/java/javase/downloads/index.html
+- Java JRE 7 or 8 (9 is currently incompatible) http://www.oracle.com/technetwork/java/javase/downloads/index.html
 - (Mac only) Xcode https://developer.apple.com/xcode
 - git https://git-scm.com
 - Docker https://www.docker.com (for local testing)
@@ -88,7 +88,7 @@ Test installation:
 
 Additional System Dependencies:
 
-- Java JDK 7+ http://www.oracle.com/technetwork/java/javase/downloads/index.html
+- Java JDK 7 or 8 (9 is currently incompatible) http://www.oracle.com/technetwork/java/javase/downloads/index.html
 - JAVA_HOME environment variable set to JDK installation path
 - Apache Ant http://ant.apache.org
 
@@ -102,6 +102,7 @@ Follow basic instructions above.  Instead of running `make bin` you can run `mak
 
 Initialize a new module populated with the ContigFilter example (module names need to be unique in KBase, so you should pick a different name):
 
+    cd ~ # or wherever you wish to place your module directory
     kb-sdk init --example -l python -u [your_kbase_user_name] MyContigFilter
 
 Enter your new module directory and do the initial build:

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -6,6 +6,17 @@ platform.  Modules include all code, specification files, and
 documentation needed to define and run a set of methods 
 in the KBase Narrative interface.
 
+VERSION: 0.1.18 (Released 1/24/2018)
+------------------------------------
+
+BACKWARDS INCOMPATIBILITES:
+
+- R support is now deprecated.
+
+BUGFIXES:
+
+- Fixed Python builds for new modules. make sdkbase is required prior to build.
+
 VERSION: 0.1.17 (Released 8/29/2017)
 ------------------------------------------
 NEW FEATURES:

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -38,7 +38,7 @@ It may be the case that someone is wrapping a tool, but is doing so in a way tha
 
 
 #### <A NAME="sys-req-dev"></A>Q: What are system requirements for development workstation?
-**A:** You will need to be able to run Docker, which if you're on a Mac means you must be running Mac OS X 10.8 or later.  Other operating systems, such as the various flavors of Linux, are fine too.  Really anywhere you can run Docker, Java, and your preferred development language (among Python, Perl, Java, or R).  You will need about 1-2 GB free to install the [dependencies](https://github.com/kbase/kb_sdk/docs/kb_sdk_dependencies.md) and the [KBase SDK](https://https://github.com/kbase/kb_sdk/doc/kb_sdk_install_and_build.md).
+**A:** You will need to be able to run Docker, which if you're on a Mac means you must be running Mac OS X 10.8 or later.  Other operating systems, such as the various flavors of Linux, are fine too.  Really anywhere you can run Docker, Java, and your preferred development language (among Python, Perl, or Java).  You will need about 1-2 GB free to install the [dependencies](https://github.com/kbase/kb_sdk/docs/kb_sdk_dependencies.md) and the [KBase SDK](https://https://github.com/kbase/kb_sdk/doc/kb_sdk_install_and_build.md).
 
 [back to top](#top)
 
@@ -50,7 +50,7 @@ It may be the case that someone is wrapping a tool, but is doing so in a way tha
 - Requires either no or fairly limited amounts of reference data
 - Uses existing data visualization widgets
 - Does not require new uploaders/downloaders
-- Wrapper written in Python, Java, R, or Perl
+- Wrapper written in Python, Java, or Perl
 
 [back to top](#top)
 
@@ -82,7 +82,7 @@ As for processing, once it's uploaded to the system (which can take awhile for l
 
 
 #### <A NAME="windows"></A>Q: Can I develop on Windows?
-**A:**  Sort of.  Your best option right now is to install [VirtualBox](https://www.virtualbox.org) with [Ubuntu Linux](https://www.ubuntu.com/desktop) and work in the Linux VM.  Many developers use this approach in KBase, and we know it works well.  Although the KBase SDK tools do not run natively in Windows, with the release of [Docker for Windows](https://docs.docker.com/docker-for-windows/) and our new experimental [Dockerized kb-sdk](kb_sdk_dockerized_install.md) we plan to fully support Windows very soon.
+**A:**  Sort of.  Your best option right now is to install [VirtualBox](https://www.virtualbox.org) with [Ubuntu Linux](https://www.ubuntu.com/desktop) and work in the Linux VM.  Many developers use this approach in KBase, and we know it works well.
 
 [back to top](#top)
 

--- a/doc/kb_sdk_create_module.md
+++ b/doc/kb_sdk_create_module.md
@@ -27,7 +27,7 @@ The basic options of the command are:
 
     kb-sdk init --example -l python -u <your_kbase_user_name> <user_name>ContigFilter
 
-This command will create a new module with the specified name `ModuleName`, configured based on the options provided.  You should always provide a username option so that the kbase.yml configuration file for your module includes you as a module owner.  The other key option is to set the programming language that you want to write your implementation in.  You can select either Python, Perl, R, or Java.
+This command will create a new module with the specified name `ModuleName`, configured based on the options provided.  You should always provide a username option so that the kbase.yml configuration file for your module includes you as a module owner.  The other key option is to set the programming language that you want to write your implementation in.  You can select either Python, Perl, or Java.
 
 The other **kb-sdk** options are:
 
@@ -37,7 +37,7 @@ The other **kb-sdk** options are:
     -e, --example    Populate your repo with an example module in the language
                      set by -l
     -l, --language   Choose a programming language to base your repo on.
-                     Currently, we support Perl, R, Python, and Java. Default is
+                     Currently, we support Perl, Python, and Java. Default is
                      Python
 
 For a simple example, let's create a new module to count the number of contigs in a KBase ContigSet object.  This is the same function that is defined in the basic example generated when you run `kbase init` with the `-e` flag, so you can always generate those files and compare.  In this example, we will instead put together the various pieces by hand.

--- a/doc/kb_sdk_dependencies.md
+++ b/doc/kb_sdk_dependencies.md
@@ -19,7 +19,7 @@ This document describes how to set up your computer to start using the KBase SDK
 
 System Dependencies:
 - Mac OS X 10.8+ (Docker requires this) or Linux.  kb-sdk does not run natively in Windows, but see [here](FAQ.md#windows) for more details.
-- (Not required for Docker-based installation) Java JRE 7+ http://www.oracle.com/technetwork/java/javase/downloads/index.html
+- (Not required for Docker-based installation) Java JRE 7 or 8 (9 is currently incompatible) http://www.oracle.com/technetwork/java/javase/downloads/index.html
 - (Mac only) Xcode https://developer.apple.com/xcode
 - git https://git-scm.com
 - Docker https://www.docker.com (for local testing)

--- a/doc/kb_sdk_impl_methods.md
+++ b/doc/kb_sdk_impl_methods.md
@@ -42,17 +42,17 @@ Here are some of the modules that might be helpful for your app:
 reports which can present text, html, and downloadable files to the user as output to your app.
 * [GenomeFileUtil](https://appdev.kbase.us/#catalog/modules/ReadsUtils) - Import/Export and Upload/Download 
 of Genome data
-*[AssemblyUtils](https://appdev.kbase.us/#catalog/modules/ReadsAlignmentUtils) - Provides tooling for interacting 
+* [AssemblyUtils](https://appdev.kbase.us/#catalog/modules/ReadsAlignmentUtils) - Provides tooling for interacting 
 with sequence assembly data in KBase.
 * [ReadsUtils](https://appdev.kbase.us/#catalog/modules/ReadsUtils) - Utilities for validating, uploading, and 
 downloading reads files. Includes FASTA and FASTQ validators. 
-*[ExpressionUtils](https://appdev.kbase.us/#catalog/modules/ExpressionUtils) - Upload, download and 
+* [ExpressionUtils](https://appdev.kbase.us/#catalog/modules/ExpressionUtils) - Upload, download and 
 export RNASeq Expression data gemerated by either StringTie or Cufflinks apps.
-*[ReadsAlignmentUtils](https://appdev.kbase.us/#catalog/modules/ReadsAlignmentUtils) - Upload and download KBase reads alignment files.
-*[DifferentialExpressionUtils](https://appdev.kbase.us/#catalog/modules/DifferentialExpressionUtils) - Upload/download/export differential expression objects and other related processing
-*[FeatureSetUtils](https://appdev.kbase.us/#catalog/modules/FeatureSetUtils) - Upload, download and 
+* [ReadsAlignmentUtils](https://appdev.kbase.us/#catalog/modules/ReadsAlignmentUtils) - Upload and download KBase reads alignment files.
+* [DifferentialExpressionUtils](https://appdev.kbase.us/#catalog/modules/DifferentialExpressionUtils) - Upload/download/export differential expression objects and other related processing
+* [FeatureSetUtils](https://appdev.kbase.us/#catalog/modules/FeatureSetUtils) - Upload, download and 
 export Genomic Feature Set data
-*[CompoundSetUtils](https://appdev.kbase.us/#catalog/modules/CompoundSetUtils) - Upload/download/export 
+* [CompoundSetUtils](https://appdev.kbase.us/#catalog/modules/CompoundSetUtils) - Upload/download/export 
 chemical compound sets
 * [DataFileUtil](https://appdev.kbase.us/#catalog/modules/DataFileUtil) - A collection of tools to 
 get data directly from the web, from the user's computer (via the staging area) or from KBase workspaces.

--- a/doc/kb_sdk_local_test_module.md
+++ b/doc/kb_sdk_local_test_module.md
@@ -74,9 +74,8 @@ Edit the local test config file (`test_local/test.cfg`) with a developer token (
 
     test_token = TEST_TOKEN
 
-*In the Docker shell*, run tests:
+In the module directory, run tests:
 
-    cd test_local
     kb-sdk test
 
 This will build your Docker container and execute all test scripts in the test directory.

--- a/sdkbase/Dockerfile
+++ b/sdkbase/Dockerfile
@@ -2,13 +2,17 @@ FROM kbase/deplbase:latest
 
 COPY ./sdkbase.build.tag /tmp/
 
-# Fix Python SSL warnings
-RUN apt-get install python-dev libffi-dev libssl-dev \
-    && pip install pyopenssl ndg-httpsclient pyasn1 \
-    && pip install requests --upgrade \
-    && pip install requests_toolbelt --upgrade \
-    && pip install 'requests[security]' --upgrade \
-    && pip install coverage
+# Update certs
+RUN apt-get update
+RUN apt-get install ca-certificates
+
+# Fix Python SSL warnings for python < 2.7.9 (system python on Trusty is 2.7.6)
+# https://github.com/pypa/pip/issues/4098
+RUN pip install pip==8.1.2
+RUN pip install --disable-pip-version-check requests requests_toolbelt pyopenssl --upgrade
+
+#install coverage tool
+RUN pip install coverage
 
 RUN \
   . /kb/dev_container/user-env.sh && \

--- a/src/java/us/kbase/mobu/ModuleBuilder.java
+++ b/src/java/us/kbase/mobu/ModuleBuilder.java
@@ -49,7 +49,7 @@ public class ModuleBuilder {
     public static final String GLOBAL_SDK_HOME_ENV_VAR = "KB_SDK_HOME";
     public static final String DEFAULT_METHOD_STORE_URL = "https://appdev.kbase.us/services/narrative_method_store/rpc";
     
-    public static final String VERSION = "1.0.17";
+    public static final String VERSION = "1.0.18";
     
     
     public static void main(String[] args) throws Exception {
@@ -192,9 +192,9 @@ public class ModuleBuilder {
 		
 		// Get chosen language
 		String language = ModuleInitializer.DEFAULT_LANGUAGE;
-		if (initArgs.language != null)
+		if (initArgs.language != null) {
 			language = initArgs.language;
-		
+		}
 		try {
 			ModuleInitializer initer = new ModuleInitializer(moduleName, userName, language, initArgs.verbose);
 			initer.initialize(initArgs.example);
@@ -470,7 +470,7 @@ public class ModuleBuilder {
     	boolean example = false;
     	
     	@Parameter(names={"-l","--language"}, description="Choose a language for developing " + 
-    			" code in your module. You can currently choose from Python, Perl, R and Java " + 
+    			" code in your module. You can currently choose from Python, Perl, and Java " + 
     			"(default=Python)")
     	String language = ModuleInitializer.DEFAULT_LANGUAGE;
     	
@@ -585,26 +585,26 @@ public class ModuleBuilder {
         		"copies of generated classes for GWT clients)")//, metaVar="<java-gwt-pckg>")     
         String javaGwtPackage = null;
 
-        @Parameter(names="--r", description="Generate a Python client with a standard default name")
+        @Parameter(names="--r", description="DEPRECATED Generate a R client with a standard default name")
         boolean rClientSide = false;
 
-        @Parameter(names="--rclname", description="Generate an R client with with the " +
+        @Parameter(names="--rclname", description="DEPRECATED Generate an R client with with the " +
                 "name provided, optionally prefixed by subdirectories separated by '/' as "+
                 "in the standard file path syntax (e.g. biokbase/mymodule/client,"+
                 "overrides the --r option).")
         String rClientName = null;
 
-        @Parameter(names="--rsrv", description="Generate an R server with a " +
+        @Parameter(names="--rsrv", description="DEPRECATED Generate an R server with a " +
                 "standard default name.  If set, Python clients will automatically be generated too.")
         boolean rServerSide = false;
 
-        @Parameter(names="--rsrvname", description="Generate an R server with the " +
+        @Parameter(names="--rsrvname", description="DEPRECATED Generate an R server with the " +
                 "name provided, optionally prefixed by subdirectories separated by '/' as "+
                 "in the standard file path syntax (e.g. biokbase/mymodule/server,"+
                 "overrides the --rsrv option).")
         String rServerName = null;
 
-        @Parameter(names="--rimplname", description="Generate an R server implementation with the " +
+        @Parameter(names="--rimplname", description="DEPRECATED Generate an R server implementation with the " +
                 "name provided, optionally prefixed by subdirectories separated by '/' as "+
                 "in the standard file path syntax (e.g. biokbase/mymodule/impl)." +
                 " If set, R server and client code will be generated too.")

--- a/src/java/us/kbase/mobu/compiler/TemplateBasedGenerator.java
+++ b/src/java/us/kbase/mobu/compiler/TemplateBasedGenerator.java
@@ -118,6 +118,10 @@ public class TemplateBasedGenerator {
             pythonClientName = service.getName() + "Client";
         genRServer = genPythonServer(genRServer, rServerName, rImplName);
         if (genRServer) {
+            System.out.println(
+                    "************************************************************************\n" +
+                    "WARNING: R support is deprecated and will be removed in a future release\n" +
+                    "************************************************************************");
             genR = true;
             if (rServerName == null)
                 rServerName = service.getName() + "Server";

--- a/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
+++ b/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
@@ -302,11 +302,11 @@ public class ModuleInitializer {
 	 * Takes a language string and returns a "qualified" form. E.g. "perl", "Perl", "pl", ".pl", should all 
 	 * return "perl", "Python", "python", ".py", and "py" should all return Python, etc.
 	 * 
-	 * Right now, we support Perl, Python, R and Java for implementation languages (nodejs next? Nope, R is first...)
+	 * Right now, we support Perl, Python and Java for implementation languages
 	 * @param language
 	 * @return
 	 */
-	private String qualifyLanguage(String language) {
+	public static String qualifyLanguage(String language) {
 		String lang = language.toLowerCase();
 		
 		String[] perlNames = {"perl", ".pl", "pl"};
@@ -321,11 +321,16 @@ public class ModuleInitializer {
 		if (Arrays.asList(javaNames).contains(lang))
 			return "java";
 		
-        String[] rNames = {"r", ".r"};
-        if (Arrays.asList(rNames).contains(lang))
-            return "r";
+		String[] rNames = {"r", ".r"};
+		if (Arrays.asList(rNames).contains(lang)) {
+			System.out.println(
+					"************************************************************************\n" +
+					"WARNING: R support is deprecated and will be removed in a future release\n" +
+					"************************************************************************");
+			return "r";
+		}
 		
 		// If we get here, then we don't recognize it! throw a runtime exception
-		throw new RuntimeException("Unrecognized language: " + language + "\n\tWe currently only support Python, Perl, R and Java.");
+		throw new RuntimeException("Unrecognized language: " + language + "\n\tWe currently only support Python, Perl, and Java.");
 	}
 }

--- a/src/java/us/kbase/mobu/renamer/test/ModuleRenamerTest.java
+++ b/src/java/us/kbase/mobu/renamer/test/ModuleRenamerTest.java
@@ -80,15 +80,6 @@ public class ModuleRenamerTest {
     }
     
     @Test
-    public void testR() throws Exception {
-        String newModuleName = TARGET_MODULE_NAME + "_r";
-        File moduleDir = initRepo("r");
-        new ModuleRenamer(moduleDir).rename(newModuleName);
-        int exitCode = ModuleTesterTest.runTestsInDocker(moduleDir, token);
-        Assert.assertEquals(0, exitCode);
-    }
-    
-    @Test
     public void testWindowsEOFs() throws Exception {
         String oldModuleName = "a_SimpleModule_for_unit_testing";
         String newModuleName = "a_SimpleModule_for_UnitTesting";

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -38,6 +38,7 @@ import us.kbase.common.service.JsonServerServlet;
 import us.kbase.common.service.JsonServerSyslog;
 import us.kbase.common.service.UObject;
 import us.kbase.common.utils.NetUtils;
+import us.kbase.mobu.initializer.ModuleInitializer;
 import us.kbase.mobu.util.DirUtils;
 import us.kbase.mobu.util.ProcessHelper;
 import us.kbase.mobu.util.TextUtils;
@@ -65,6 +66,8 @@ public class ModuleTester {
         if (kbaseYmlConfig.get("data-version") != null) {
             moduleContext.put("data_version", kbaseYmlConfig.get("data-version"));
         }
+        // this next line will throw an exception if the language is unsupported
+        ModuleInitializer.qualifyLanguage((String) kbaseYmlConfig.get("service-language"));
         moduleContext.put("os_name", System.getProperty("os.name"));
     }
     

--- a/src/java/us/kbase/mobu/tester/test/ModuleTesterTest.java
+++ b/src/java/us/kbase/mobu/tester/test/ModuleTesterTest.java
@@ -172,16 +172,6 @@ public class ModuleTesterTest {
 	}
 
     @Test
-    public void testRModuleExample() throws Exception {
-        System.out.println("Test [testRModuleExample]");
-        String lang = "r";
-        String moduleName = SIMPLE_MODULE_NAME + "R";
-        init(lang, moduleName);
-        int exitCode = runTestsInDocker(moduleName);
-        Assert.assertEquals(0, exitCode);
-    }
-
-    @Test
     public void testRModuleError() throws Exception {
         System.out.println("Test [testRModuleError]");
         String lang = "r";

--- a/src/java/us/kbase/templates/module_dockerfile.vm.properties
+++ b/src/java/us/kbase/templates/module_dockerfile.vm.properties
@@ -9,20 +9,6 @@ MAINTAINER #if($username)${username}#{else}KBase Developer#{end}
 
 # RUN apt-get update
 
-#if( $language == "python")
-# Here we install a python coverage tool and an
-# https library that is out of date in the base image.
-
-RUN pip install coverage
-
-# update security libraries in the base image
-RUN pip install cffi --upgrade \
-    && pip install pyopenssl --upgrade \
-    && pip install ndg-httpsclient --upgrade \
-    && pip install pyasn1 --upgrade \
-    && pip install requests --upgrade \
-    && pip install 'requests[security]' --upgrade
-#end
 #if($example && $language == "java")
 # download a fasta reader/writer
 RUN cd /kb/deployment/lib/jars \

--- a/test_scripts/py_module_tests/test_auth_client.py
+++ b/test_scripts/py_module_tests/test_auth_client.py
@@ -38,6 +38,7 @@ class TestAuth(unittest.TestCase):
             raise ValueError('Missing {} from test config'.format(cls.TOKEN1))
         if not cls.token2:
             raise ValueError('Missing {} from test config'.format(cls.TOKEN2))
+        print('Authorization url: ' + authurl)
         cls.user1 = cls.get_user(authurl, cls.token1)
         cls.user2 = cls.get_user(authurl, cls.token2)
         if cls.user1 == cls.user2:
@@ -49,6 +50,10 @@ class TestAuth(unittest.TestCase):
     def get_user(cls, authurl, token):
         d = {'token': token, 'fields': 'user_id'}
         ret = requests.post(authurl, data=d)
+        if ret.status_code != 200:
+            print('Failed getting token: ' + str(ret.status_code))
+            print(ret.text)
+            raise Exception('Failed getting token: ' + str(ret.status_code))
         return ret.json()['user_id']
 
     def test_get_user(self):


### PR DESCRIPTION
A brand new python user's build currently fails-  there's an incompatibility between sdkbase and the generated Dockerfile.

Current users will likely not see this problem as sdkbase and their module are built already.

* Bump version
* Move all the python SSL warning fixes to sdkbase
* Note that Java 9 is currently incompatible
* Deprecate R.
  * Remove failing R test
* Fix java tests by updating certs
* Minor cleanup

```
$ kb-sdk init -u gaprice -e -l R Foo
************************************************************************
WARNING: R support is deprecated and will be removed in a future release
************************************************************************
Done! Your module is available in the Foo directory.
Compile and run the example methods with the following inputs:
  cd Foo
  make          (required after making changes to Foo.spec)
  kb-sdk test   (will require setting test user account credentials in
test_local/test.cfg)

  
$ cd Foo
$ make
kb-sdk compile Foo.spec \
		--out lib \
		--plclname Foo::FooClient \
		--jsclname javascript/Client \
		--pyclname Foo.FooClient \
		--rclname Foo/FooClient \
		--javasrc src \
		--java \
		--rsrvname Foo/FooServer \
		--rimplname Foo/FooImpl;
KBase SDK version 1.0.18 (commit 389297a)
************************************************************************
WARNING: R support is deprecated and will be removed in a future release
************************************************************************
  
$ gedit test_local/test.cfg 
$ kb-sdk test
************************************************************************
WARNING: R support is deprecated and will be removed in a future release
************************************************************************

Validating module in (/home/crusherofheads/temp/Foo)
```