### PR TITLE
Sdkbase2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,12 @@ deploy-scripts:
 	fi;
 	$(ANT) deploy_bin -DBIN_TARGET=$(TARGET)/bin -DBIN_LIB_TARGET=$(TARGET)/lib -DKBASE_COMMON_JAR=$(KBASE_COMMON_JAR)
 
-sdkbase:
+# The SDK base image has been decoupled from this repo and is pulled from dockerhub or built from
+# the kbase/sdkbase repo
+#sdkbase:
 	# docker rmi -f kbase/deplbase:latest
-	cd sdkbase && ./makeconfig
-	docker build --no-cache -t kbase/kbase:sdkbase2.latest sdkbase
+#	cd sdkbase && ./makeconfig
+#	docker build --no-cache -t kbase/kbase:sdkbase2.latest sdkbase
 
 test: submodule-init
 	@echo "Running unit tests"

--- a/doc/kb_sdk_troubleshooting.md
+++ b/doc/kb_sdk_troubleshooting.md
@@ -14,7 +14,7 @@
 When you try to run *make sdkbase*, if you see a message like:
 
 ```
-docker build -t kbase/kbase:sdkbase2.latest sdkbase
+docker build -t kbase/sdkbase2:v1.0 sdkbase
 Post http:///var/run/docker.sock/v1.20/build?cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile&memory=0&memswap=0&rm=1&t=kbase%2Fkbase%3Asdkbase.latest&ulimits=null: dial unix /var/run/docker.sock: no such file or directory.
 * Are you trying to connect to a TLS-enabled daemon without TLS?
 * Is your docker daemon up and running?

--- a/entrypoint
+++ b/entrypoint
@@ -20,7 +20,7 @@ exec docker run -it --rm -v \$HOME:\$HOME -u \$(id -u) -w \$(pwd) -v /run/docker
 EOF
 elif [ "z$1" = "zsdkbase" ] ; then
     echo "Pulling and tagging the base image"
-    docker pull kbase/kbase:sdkbase2.latest
+    docker pull kbase/sdkbase2:v1.0
 elif [ "z$1" = "zprune" ] ; then
   echo "Used during build to shrink image.  Not needed by the user."
   for f in $(find /src/submodules/jars/lib/jars -type f -name '*.jar') ; do

--- a/src/java/us/kbase/mobu/initializer/ModuleInitializerException.java
+++ b/src/java/us/kbase/mobu/initializer/ModuleInitializerException.java
@@ -1,0 +1,20 @@
+package us.kbase.mobu.initializer;
+
+/** Thrown when a configuration is invalid and the service cannot start.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class ModuleInitializerException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public ModuleInitializerException(final String message) {
+		super(message);
+	}
+	
+	public ModuleInitializerException(
+			final String message,
+			final Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/java/us/kbase/templates/module_dockerfile.vm.properties
+++ b/src/java/us/kbase/templates/module_dockerfile.vm.properties
@@ -1,4 +1,4 @@
-FROM kbase/sdkbase2:v1.0
+FROM ${docker_image}:${image_tag}
 MAINTAINER #if($username)${username}#{else}KBase Developer#{end}
 
 # -----------------------------------------

--- a/src/java/us/kbase/templates/module_dockerfile.vm.properties
+++ b/src/java/us/kbase/templates/module_dockerfile.vm.properties
@@ -1,4 +1,4 @@
-FROM kbase/kbase:sdkbase2.latest
+FROM kbase/sdkbase2:v1.0
 MAINTAINER #if($username)${username}#{else}KBase Developer#{end}
 
 # -----------------------------------------


### PR DESCRIPTION
Remove the build of sdkbase image from kb_sdk, and update the templates so that the base image used in "kb-sdk init" has a parameterized image name and tag.
