### PR TITLE
Python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /TestAsyncPerl/
 /reports/
 /test_scripts/ee_mock_service/
+/test_scripts/test.cfg
 /*/*.pyc
 /*/*/*.pyc
 /*/*/*/*.pyc

--- a/lib/biokbase/common/filetools.py
+++ b/lib/biokbase/common/filetools.py
@@ -41,7 +41,7 @@ class ExcelDictReader(object):
                 raise IndexError('Workbook has no sheet for index {}'.format(
                     sheet))
             self._sheet = self._xl.sheet_by_index(sheet)
-        elif isinstance(sheet, basestring):
+        elif isinstance(sheet, str):
             if sheet not in self._xl.sheet_names():
                 raise ValueError('No such sheet name: {}'.format(sheet))
             self._sheet = self._xl.sheet_by_index(sheet)
@@ -60,7 +60,7 @@ class ExcelDictReader(object):
         if not self._sheet:
             raise StopIteration('No sheet set')
         s = self._sheet
-        for i in xrange(1, s.nrows):
+        for i in range(1, s.nrows):
             self._rownum = i + 1
             r = convert_xl_row(self._xl, self._sheet.name, i)
             ret = {n: v for n, v in zip(self._heads, r)}

--- a/lib/biokbase/common/itertools.py
+++ b/lib/biokbase/common/itertools.py
@@ -19,7 +19,7 @@ def chunkiter(iterable, size):
   """
     def inneriter(first, iterator, size):
         yield first
-        for _ in xrange(size - 1):
+        for _ in range(size - 1):
             yield iterator.next()
     it = iter(iterable)
     while True:

--- a/lib/biokbase/log.py
+++ b/lib/biokbase/log.py
@@ -67,7 +67,7 @@ METHODS
 """
 
 import json as _json
-import urllib2 as _urllib2
+import urllib.request as _urllib
 import syslog as _syslog
 import platform as _platform
 import inspect as _inspect
@@ -116,11 +116,10 @@ _MLOG_TO_SYSLOG = [_syslog.LOG_EMERG, _syslog.LOG_ALERT, _syslog.LOG_CRIT,
                  _syslog.LOG_DEBUG]
 #ALLOWED_LOG_LEVELS = set(_MLOG_TEXT_TO_LEVEL.values())
 _MLOG_LEVEL_TO_TEXT = {}
-for k, v in _MLOG_TEXT_TO_LEVEL.iteritems():
+for k, v in _MLOG_TEXT_TO_LEVEL.items():
     _MLOG_LEVEL_TO_TEXT[v] = k
 LOG_LEVEL_MIN = min(_MLOG_LEVEL_TO_TEXT.keys())
 LOG_LEVEL_MAX = max(_MLOG_LEVEL_TO_TEXT.keys())
-del k, v
 
 
 class log(object):
@@ -220,9 +219,9 @@ class log(object):
         if (api_url):
             subsystem_api_url = api_url + "/" + self._subsystem
             try:
-                data = _json.load(_urllib2.urlopen(subsystem_api_url,
+                data = _json.load(_urllib.urlopen(subsystem_api_url,
                                                    timeout=5))
-            except _urllib2.URLError, e:
+            except _urllib.URLError as e:
                 code_ = None
                 if hasattr(e, 'code'):
                     code_ = ' ' + str(e.code)
@@ -311,7 +310,7 @@ class log(object):
 
     def _syslog(self, facility, level, ident, message):
         _syslog.openlog(ident, facility)
-        if isinstance(message, basestring):
+        if isinstance(message, str):
             _syslog.syslog(_MLOG_TO_SYSLOG[level], message)
         else:
             try:
@@ -327,7 +326,7 @@ class log(object):
                         _platform.node(), ident + ': '])
         try:
             with open(self.get_log_file(), 'a') as log:
-                if isinstance(message, basestring):
+                if isinstance(message, str):
                     log.write(ident + message + '\n')
                 else:
                     try:

--- a/src/java/us/kbase/templates/authclient.py
+++ b/src/java/us/kbase/templates/authclient.py
@@ -24,7 +24,7 @@ class TokenCache(object):
         self._halfmax = maxsize / 2  # int division to round down
 
     def get_user(self, token):
-        token = hashlib.sha256(token).hexdigest()
+        token = hashlib.sha256(token.encode('utf-8')).hexdigest()
         with self._lock:
             usertime = self._cache.get(token)
         if not usertime:
@@ -40,12 +40,12 @@ class TokenCache(object):
             raise ValueError('Must supply token')
         if not user:
             raise ValueError('Must supply user')
-        token = hashlib.sha256(token).hexdigest()
+        token = hashlib.sha256(token.encode('utf-8')).hexdigest()
         with self._lock:
             self._cache[token] = [user, _time.time()]
             if len(self._cache) > self._maxsize:
                 for i, (t, _) in enumerate(sorted(self._cache.items(),
-                                                  key=lambda (_, v): v[1])):
+                                                  key=lambda it: it[1][1])):
                     if i <= self._halfmax:
                         del self._cache[t]
                     else:

--- a/src/java/us/kbase/templates/authclient.py
+++ b/src/java/us/kbase/templates/authclient.py
@@ -44,8 +44,8 @@ class TokenCache(object):
         with self._lock:
             self._cache[token] = [user, _time.time()]
             if len(self._cache) > self._maxsize:
-                for i, (t, _) in enumerate(sorted(self._cache.items(),
-                                                  key=lambda it: it[1][1])):
+                for i, (t, _) in enumerate(sorted(list(self._cache.items()),
+                                                  key=lambda __v: __v[1][1])):
                     if i <= self._halfmax:
                         del self._cache[t]
                     else:

--- a/src/java/us/kbase/templates/baseclient.py
+++ b/src/java/us/kbase/templates/baseclient.py
@@ -121,7 +121,7 @@ class BaseClient(object):
             self, url=None, timeout=30 * 60, user_id=None,
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
-            auth_svc='https://kbase.us/services/authorization/Sessions/Login',
+            auth_svc='https://kbase.us/services/auth/api/legacy/KBase/Sessions/Login',
             lookup_url=False,
             async_job_check_time_ms=100,
             async_job_check_time_scale_percent=150,

--- a/src/java/us/kbase/templates/module_dockerfile.vm.properties
+++ b/src/java/us/kbase/templates/module_dockerfile.vm.properties
@@ -1,4 +1,8 @@
+#if( $language == "python")
+FROM jjeffryes/kbasepythonsdk:latest
+#else
 FROM kbase/kbase:sdkbase.latest
+#end
 MAINTAINER #if($username)${username}#{else}KBase Developer#{end}
 
 # -----------------------------------------

--- a/src/java/us/kbase/templates/module_prepare_deploy_cfg.vm.properties
+++ b/src/java/us/kbase/templates/module_prepare_deploy_cfg.vm.properties
@@ -2,8 +2,12 @@ import sys
 import os
 import os.path
 from jinja2 import Template
-from ConfigParser import ConfigParser
-import StringIO
+try:
+    from configparser import ConfigParser
+    from io import StringIO
+except ImportError:
+    from ConfigParser import ConfigParser
+    from StringIO import StringIO
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:

--- a/src/java/us/kbase/templates/python_client.vm.properties
+++ b/src/java/us/kbase/templates/python_client.vm.properties
@@ -27,7 +27,7 @@ class ${module.module_name}(object):
             self, url=None, timeout=30 * 60, user_id=None,
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
-            auth_svc='https://kbase.us/services/authorization/Sessions/Login'#if($any_async || $async_version || $dynserv_ver),
+            auth_svc='https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login'#if($any_async || $async_version || $dynserv_ver),
             service_ver=#if($service_ver)'$service_ver'#{else}None#{end}#if($any_async || $async_version),
             async_job_check_time_ms=100, async_job_check_time_scale_percent=150, 
             async_job_check_max_time_ms=300000#{end}#{end}):

--- a/src/java/us/kbase/templates/python_impl.vm.properties
+++ b/src/java/us/kbase/templates/python_impl.vm.properties
@@ -8,7 +8,7 @@ ${module.py_module_header}#END_HEADER
 #set( $void = $specToPy.put("mapping", "dict") )
 #set( $void = $specToPy.put("int", "int") )
 #set( $void = $specToPy.put("float", "float") )
-#set( $void = $specToPy.put("string", "basestring") )
+#set( $void = $specToPy.put("string", "str") )
 #set( $void = $specToPy.put("UnspecifiedObject", "object") )
 
 

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -123,7 +123,7 @@ class JSONRPCServiceCustom(JSONRPCService):
             # Exception was raised inside the method.
             newerr = JSONServerError()
             newerr.trace = traceback.format_exc()
-            if isinstance(e.message, basestring):
+            if isinstance(e.message, str):
                 newerr.data = e.message
             else:
                 # Some exceptions embed other exceptions as the message
@@ -189,7 +189,7 @@ class JSONRPCServiceCustom(JSONRPCService):
 
     def _handle_request(self, ctx, request):
         """Handles given request and returns its response."""
-        if self.method_data[request['method']].has_key('types'):  # noqa @IgnorePep8
+        if 'types' in self.method_data[request['method']]:  # noqa @IgnorePep8
             self._validate_params_types(request['method'], request['params'])
 
         result = self._call_method(ctx, request)

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -11,7 +11,7 @@ from jsonrpcbase import JSONRPCService, InvalidParamsError, KeywordError,\
     JSONRPCError, InvalidRequestError
 from jsonrpcbase import ServerError as JSONServerError
 from os import environ
-from ConfigParser import ConfigParser
+from configparser import ConfigParser
 from biokbase import log
 import requests as _requests
 import random as _random
@@ -442,7 +442,7 @@ class Application(object):
                                 ctx['user_id'] = user
                                 ctx['authenticated'] = 1
                                 ctx['token'] = token
-                            except Exception, e:
+                            except Exception as e:
                                 if auth_req == 'required':
                                     err = JSONServerError()
                                     err.data = \
@@ -544,7 +544,7 @@ try:
 # a wsgi container that has enabled gevent, such as
 # uwsgi with the --gevent option
     if config is not None and config.get('gevent_monkeypatch_all', False):
-        print "Monkeypatching std libraries for async"
+        print("Monkeypatching std libraries for async")
         from gevent import monkey
         monkey.patch_all()
     uwsgi.applications = {'': application}
@@ -568,7 +568,7 @@ def start_server(host='localhost', port=0, newprocess=False):
         raise RuntimeError('server is already running')
     httpd = make_server(host, port, application)
     port = httpd.server_address[1]
-    print "Listening on port %s" % port
+    print("Listening on port %s" % port)
     if newprocess:
         _proc = Process(target=httpd.serve_forever)
         _proc.daemon = True
@@ -649,7 +649,7 @@ if __name__ == "__main__":
         opts, args = getopt(sys.argv[1:], "", ["port=", "host="])
     except GetoptError as err:
         # print help information and exit:
-        print str(err)  # will print something like "option -a not recognized"
+        print(str(err))  # will print something like "option -a not recognized"
         sys.exit(2)
     port = 9999
     host = 'localhost'
@@ -658,7 +658,7 @@ if __name__ == "__main__":
             port = int(a)
         elif o == '--host':
             host = a
-            print "Host set to %s" % host
+            print("Host set to %s" % host)
         else:
             assert False, "unhandled option"
 

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -1,24 +1,31 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from wsgiref.simple_server import make_server
-import sys
-import json
-import traceback
 import datetime
-from multiprocessing import Process
+import json
+import os
+import random as _random
+import sys
+import traceback
 from getopt import getopt, GetoptError
-from jsonrpcbase import JSONRPCService, InvalidParamsError, KeywordError,\
+from multiprocessing import Process
+from os import environ
+from wsgiref.simple_server import make_server
+
+import requests as _requests
+from jsonrpcbase import JSONRPCService, InvalidParamsError, KeywordError, \
     JSONRPCError, InvalidRequestError
 from jsonrpcbase import ServerError as JSONServerError
-from os import environ
-from configparser import ConfigParser
+
 from biokbase import log
-import requests as _requests
-import random as _random
-import os
+from biokbase.catalog.authclient import KBaseAuth as _KBaseAuth
 #if( $authenticated )
 from ${modules[0].pypackage}authclient import KBaseAuth as _KBaseAuth
 #end
+
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
 
 DEPLOY = 'KB_DEPLOYMENT_CONFIG'
 SERVICE = 'KB_SERVICE_NAME'
@@ -54,7 +61,7 @@ config = get_config()
 #set( $void = $specToPy.put("mapping", "dict") )
 #set( $void = $specToPy.put("int", "int") )
 #set( $void = $specToPy.put("float", "float") )
-#set( $void = $specToPy.put("string", "basestring") )
+#set( $void = $specToPy.put("string", "str") )
 #set( $void = $specToPy.put("UnspecifiedObject", "object") )
 #foreach( $module in $modules )
 #set( $mn = $module.module_name )
@@ -189,7 +196,7 @@ class JSONRPCServiceCustom(JSONRPCService):
 
     def _handle_request(self, ctx, request):
         """Handles given request and returns its response."""
-        if 'types' in self.method_data[request['method']]:  # noqa @IgnorePep8
+        if 'types' in self.method_data[request['method']]:
             self._validate_params_types(request['method'], request['params'])
 
         result = self._call_method(ctx, request)
@@ -474,11 +481,11 @@ class Application(object):
                     rpc_result = self.process_error(err, ctx, req,
                                                     traceback.format_exc())
 
-        # print 'Request method was %s\n' % environ['REQUEST_METHOD']
-        # print 'Environment dictionary is:\n%s\n' % pprint.pformat(environ)
-        # print 'Request body was: %s' % request_body
-        # print 'Result from the method call is:\n%s\n' % \
-        #    pprint.pformat(rpc_result)
+        # print('Request method was %s\n' % environ['REQUEST_METHOD'])
+        # print('Environment dictionary is:\n%s\n' % pprint.pformat(environ))
+        # print('Request body was: %s' % request_body)
+        # print('Result from the method call is:\n%s\n' % \
+        #    pprint.pformat(rpc_result))
 
         if rpc_result:
             response_body = rpc_result
@@ -663,7 +670,7 @@ if __name__ == "__main__":
             assert False, "unhandled option"
 
     start_server(host=host, port=port)
-#    print "Listening on port %s" % port
+#    print("Listening on port %s" % port)
 #    httpd = make_server( host, port, application)
 #
 #    httpd.serve_forever()

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -492,7 +492,7 @@ class Application(object):
             ('content-type', 'application/json'),
             ('content-length', str(len(response_body)))]
         start_response(status, response_headers)
-        return [response_body]
+        return [response_body.encode('utf8')]
 
     def process_error(self, error, context, request, trace=None):
         if trace:

--- a/test_scripts/py_module_tests/test_auth_client.py
+++ b/test_scripts/py_module_tests/test_auth_client.py
@@ -7,9 +7,13 @@ from __future__ import print_function
 
 import unittest
 
+try:
+    from configparser import ConfigParser as _ConfigParser  # py 3
+except ImportError:
+    from ConfigParser import ConfigParser as _ConfigParser  # py 2
+
 from authclient import KBaseAuth  # @UnresolvedImport
 import os
-from ConfigParser import ConfigParser
 import requests
 from requests import ConnectionError
 
@@ -27,7 +31,7 @@ class TestAuth(unittest.TestCase):
         configfile = os.path.abspath(os.path.dirname(
             os.path.abspath(__file__)) + '/../test.cfg')
         print('Loading test config from ' + configfile)
-        cfg = ConfigParser()
+        cfg = _ConfigParser()
         cfg.read(configfile)
         authurl = cfg.get(cls.CFG_SEC, cls.AUTHURL)
         cls.token1 = cfg.get(cls.CFG_SEC, cls.TOKEN1)
@@ -81,9 +85,9 @@ class TestAuth(unittest.TestCase):
         kba2 = KBaseAuth('https://thisisasuperfakeurlihope.com')
         with self.assertRaises(ConnectionError) as context:
             kba2.get_user(self.token1)
-        self.assertIn('not known', str(context.exception.message))
+        self.assertIn('not known', str(context.exception.args[0]))
 
     def fail_get_user(self, token, error):
         with self.assertRaises(ValueError) as context:
             self.kba.get_user(token)
-        self.assertEqual(error, str(context.exception.message))
+        self.assertEqual(error, str(context.exception.args[0]))

--- a/test_scripts/py_module_tests/test_token_cache.py
+++ b/test_scripts/py_module_tests/test_token_cache.py
@@ -34,14 +34,14 @@ class TestTokenCache(unittest.TestCase):
     def test_drop_tokens(self):
         sz = 4
         tc = TokenCache(sz)
-        for x in xrange(1, sz + 1):
+        for x in range(1, sz + 1):
             tc.add_valid_token(str(x), x)
-        for x in xrange(1, sz + 1):
+        for x in range(1, sz + 1):
             self.assertEqual(x, tc.get_user(str(x)))
 
         # shouldn't dump the cache
         tc.add_valid_token('2', 2)
-        for x in xrange(1, sz + 1):
+        for x in range(1, sz + 1):
             self.assertEqual(x, tc.get_user(str(x)))
 
         # should dump the cache
@@ -54,4 +54,4 @@ class TestTokenCache(unittest.TestCase):
     def fail_set(self, token, user, error):
         with self.assertRaises(ValueError) as context:
             TokenCache().add_valid_token(token, user)
-        self.assertEqual(error, str(context.exception.message))
+        self.assertEqual(error, str(context.exception.args[0]))

--- a/test_scripts/python/run_client.py
+++ b/test_scripts/python/run_client.py
@@ -36,10 +36,7 @@ def main(argv):
         elif opt in ("-t", "--token"):
             token = arg
         elif opt in ("-a", "--asyncchecktime"):
-            try:
-                async_job_check_time_ms = long(arg)
-            except NameError:
-                async_job_check_time_ms = int(arg)
+            async_job_check_time_ms = int(arg)
         elif opt in ("-g", "--package"):
             module_file = arg
         elif opt in ("-c", "--class"):

--- a/test_scripts/python/test_client.py
+++ b/test_scripts/python/test_client.py
@@ -2,12 +2,14 @@ import sys
 import getopt
 import json
 
+
 def getErrorMessage(error):
     error_type = type(error).__name__
     message = error.__str__()
     if error_type == 'ServerError':
         message = error.data
     return message
+
 
 def main(argv):
     sys.path.append('./')
@@ -31,10 +33,7 @@ def main(argv):
         elif opt in ("-o", "--token"):
             token = arg
         elif opt in ("-a", "--asyncchecktime"):
-            try:
-                async_job_check_time_ms = long(arg)
-            except NameError:
-                async_job_check_time_ms = int(arg)
+            async_job_check_time_ms = int(arg)
     fh = open(tests_filepath)
     tests_json = json.load(fh)
     module_file = tests_json['package']
@@ -100,6 +99,7 @@ def main(argv):
         else:
             print('Unsupported outcome status: ' + expected_status)
             sys.exit(1)
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
These are my changes to make the kb_sdk generate python3 modules. It replaces the current python2 templates with python3 versions and sets up the module's dockerfile to inherit from a python3 base image which uses miniconda3 as the default python interpreter

I was never able to get all the tests to work correctly. The nose (not-J unit) python tests run and I confirmed functionality by building and testing a SDK module (Filter Contigs) and a dynamic service (Biochemistry API) in Python3