### PR TITLE
Remove makefile compilation flags to generate client code

### DIFF
--- a/src/java/us/kbase/mobu/compiler/TemplateBasedGenerator.java
+++ b/src/java/us/kbase/mobu/compiler/TemplateBasedGenerator.java
@@ -95,8 +95,6 @@ public class TemplateBasedGenerator {
         if (gitCommitHash == null)
             gitCommitHash = "";
         KbService service = srvs.get(0);
-        if (genJs && jsClientName == null)
-            jsClientName = service.getName() + "Client";
         genPerlServer = genPerlServer(genPerlServer, perlServerName, perlImplName, perlPsgiName);
         if (genPerlServer) {
             genPerl = true;
@@ -106,16 +104,12 @@ public class TemplateBasedGenerator {
             	perlPsgiName = service.getName() + ".psgi";
             }
         }
-        if (genPerl && perlClientName == null)
-            perlClientName = service.getName() + "Client";
         genPythonServer = genPythonServer(genPythonServer, pythonServerName, pythonImplName);
         if (genPythonServer) {
             genPython = true;
             if (pythonServerName == null)
                 pythonServerName = service.getName() + "Server";
         }
-        if (genPython && pythonClientName == null)
-            pythonClientName = service.getName() + "Client";
         genRServer = genPythonServer(genRServer, rServerName, rImplName);
         if (genRServer) {
             System.out.println(
@@ -126,8 +120,6 @@ public class TemplateBasedGenerator {
             if (rServerName == null)
                 rServerName = service.getName() + "Server";
         }
-        if (genR && rClientName == null)
-            rClientName = service.getName() + "Client";
         Map<String, Object> context = service.forTemplates(perlImplName, pythonImplName);
         if (defaultUrl != null)
             context.put("default_service_url", defaultUrl);

--- a/src/java/us/kbase/templates/module_makefile.vm.properties
+++ b/src/java/us/kbase/templates/module_makefile.vm.properties
@@ -29,14 +29,6 @@ all: compile build build-startup-script build-executable-script build-test-scrip
 compile:
 	kb-sdk compile $(SPEC_FILE) \
 		--out $(LIB_DIR) \
-		--plclname $(SERVICE_CAPS)::$(SERVICE_CAPS)Client \
-		--jsclname javascript/Client \
-		--pyclname $(SERVICE_CAPS).$(SERVICE_CAPS)Client \
-#if($language == "r")
-		--rclname $(SERVICE_CAPS)/$(SERVICE_CAPS)Client \
-#end
-		--javasrc src \
-		--java \
 #if($language == "python")
 		--pysrvname $(SERVICE_CAPS).$(SERVICE_CAPS)Server \
 		--pyimplname $(SERVICE_CAPS).$(SERVICE_CAPS)Impl;
@@ -49,6 +41,8 @@ compile:
 #if($language == "java")
 		--javasrv \
 		--javapackage ${java_package_parent};
+		--javasrc src \
+		--java \
 #end
 #if($language == "r")
 		--rsrvname $(SERVICE_CAPS)/$(SERVICE_CAPS)Server \

--- a/src/java/us/kbase/templates/module_makefile.vm.properties
+++ b/src/java/us/kbase/templates/module_makefile.vm.properties
@@ -41,7 +41,6 @@ compile:
 #if($language == "java")
 		--javasrv \
 		--javapackage ${java_package_parent};
-		--javasrc src \
 #end
 #if($language == "r")
 		--rsrvname $(SERVICE_CAPS)/$(SERVICE_CAPS)Server \

--- a/src/java/us/kbase/templates/module_makefile.vm.properties
+++ b/src/java/us/kbase/templates/module_makefile.vm.properties
@@ -42,7 +42,6 @@ compile:
 		--javasrv \
 		--javapackage ${java_package_parent};
 		--javasrc src \
-		--java \
 #end
 #if($language == "r")
 		--rsrvname $(SERVICE_CAPS)/$(SERVICE_CAPS)Server \


### PR DESCRIPTION
I've tested things manually only by generating/running/testing some apps -- all looked good.

I left the `--java` flag. It seems to generate java client code in `/src`. It looks like `--javasrc src` def needs to be in there for the java case.