### PR TITLE
remove -user $(id -u) setting which causes issues running local tests

### DIFF
--- a/src/java/us/kbase/mobu/ModuleBuilder.java
+++ b/src/java/us/kbase/mobu/ModuleBuilder.java
@@ -64,7 +64,7 @@ public class ModuleBuilder {
     	InitCommandArgs initArgs = new InitCommandArgs();
     	jc.addCommand(INIT_COMMAND, initArgs);
 
-    	// add the 'compile' command
+    	// add the 'validate' command
     	ValidateCommandArgs validateArgs = new ValidateCommandArgs();
     	jc.addCommand(VALIDATE_COMMAND, validateArgs);
     	

--- a/src/java/us/kbase/mobu/runner/ModuleRunner.java
+++ b/src/java/us/kbase/mobu/runner/ModuleRunner.java
@@ -120,10 +120,6 @@ public class ModuleRunner {
         File runLocalSh = new File(runDir, "run_local.sh");
         File runDockerSh = new File(runDir, "run_docker.sh");
         if (!runLocalSh.exists()) {
-            final boolean isMac = System.getProperty("os.name").toLowerCase()
-                    .contains("mac");
-            final boolean isWin = System.getProperty("os.name").toLowerCase()
-                    .contains("win");
             FileUtils.writeLines(runLocalSh, Arrays.asList(
                     "#!/bin/bash",
                     "sdir=\"$(cd \"$(dirname \"$(readlink -f \"$0\")\")\" && pwd)\"",
@@ -132,7 +128,6 @@ public class ModuleRunner {
                     "docker_image=$3",
                     "mount_points=$4",
                     "$sdir/run_docker.sh run " +
-                    (isMac || isWin ? "" : "--user $(id -u) ") +
                     "-v $sdir/workdir:/kb/module/work $mount_points " +
                     "-e \"SDK_CALLBACK_URL=$callback_url\" --name $cnt_id $docker_image async"));
             ProcessHelper.cmd("chmod", "+x", runLocalSh.getCanonicalPath()).exec(runDir);

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -160,8 +160,6 @@ public class ModuleTester {
         ProcessHelper.cmd("chmod", "+x", runDockerSh.getCanonicalPath()).exec(tlDir);
         String moduleName = (String)kbaseYmlConfig.get("module-name");
         String imageName = "test/" + moduleName.toLowerCase() + ":latest";
-        if (!buildNewDockerImageWithCleanup(moduleDir, tlDir, runDockerSh, imageName))
-            return 1;
         File subjobsDir = new File(tlDir, "subjobs");
         if (subjobsDir.exists())
             TextUtils.deleteRecursively(subjobsDir);
@@ -169,6 +167,8 @@ public class ModuleTester {
         if (scratchDir.exists())
             TextUtils.deleteRecursively(scratchDir);
         scratchDir.mkdir();
+        if (!buildNewDockerImageWithCleanup(moduleDir, tlDir, runDockerSh, imageName))
+            return 1;
         ///////////////////////////////////////////////////////////////////////////////////////////
         int callbackPort = NetUtils.findFreePort();
         String[] callbackNetworks = null;

--- a/src/java/us/kbase/mobu/tester/SDKSubsequentCallRunner.java
+++ b/src/java/us/kbase/mobu/tester/SDKSubsequentCallRunner.java
@@ -86,14 +86,9 @@ public class SDKSubsequentCallRunner extends SubsequentCallRunner {
         final Path runSubJobsSh = config.getWorkDir().toAbsolutePath()
                 .resolve("run_subjob.sh");
         if (Files.notExists(runSubJobsSh)) {
-            final boolean isMac = System.getProperty("os.name").toLowerCase()
-                    .contains("mac");
-            final boolean isWin = System.getProperty("os.name").toLowerCase()
-                    .contains("win");
             final String dockerRunCmd = config.getWorkDir().toAbsolutePath() +
-                    "/run_docker.sh run --rm " + (isMac || isWin ? "" : "--user $(id -u) ") +
-                    "-v " + config.getWorkDir().resolve(SUBJOBSDIR)
-                        .toAbsolutePath() + 
+                    "/run_docker.sh run --rm " + "-v " +
+                     config.getWorkDir().resolve(SUBJOBSDIR).toAbsolutePath() +
                     "/$1/" + WORKDIR + ":/kb/module/work -v " +
                     getSharedScratchDir(config).toAbsolutePath() +
                     ":/kb/module/work/tmp $4 -e \"SDK_CALLBACK_URL=$3\" $2 async";

--- a/src/java/us/kbase/templates/module_makefile.vm.properties
+++ b/src/java/us/kbase/templates/module_makefile.vm.properties
@@ -7,6 +7,7 @@ LIB_DIR = lib
 SCRIPTS_DIR = scripts
 TEST_DIR = test
 LBIN_DIR = bin
+WORK_DIR = work/tmp
 #if($language == "java")
 TARGET ?= /kb/deployment
 JARS_DIR = $(TARGET)/lib/jars
@@ -120,6 +121,7 @@ build-test-script:
 	echo 'script_dir=$$(dirname "$$(readlink -f "$$0")")' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'export KB_DEPLOYMENT_CONFIG=$$script_dir/../deploy.cfg' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'export KB_AUTH_TOKEN=`cat /kb/module/work/token`' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
+	echo 'rm -rf $(WORK_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 #if($language == "perl")
 	echo 'export PERL5LIB=$$script_dir/../$(LIB_DIR):$$PATH:$$PERL5LIB' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'cd $$script_dir/../$(TEST_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)

--- a/src/java/us/kbase/templates/module_makefile.vm.properties
+++ b/src/java/us/kbase/templates/module_makefile.vm.properties
@@ -7,7 +7,7 @@ LIB_DIR = lib
 SCRIPTS_DIR = scripts
 TEST_DIR = test
 LBIN_DIR = bin
-WORK_DIR = work/tmp
+WORK_DIR = /kb/module/work/tmp
 #if($language == "java")
 TARGET ?= /kb/deployment
 JARS_DIR = $(TARGET)/lib/jars
@@ -121,7 +121,9 @@ build-test-script:
 	echo 'script_dir=$$(dirname "$$(readlink -f "$$0")")' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'export KB_DEPLOYMENT_CONFIG=$$script_dir/../deploy.cfg' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'export KB_AUTH_TOKEN=`cat /kb/module/work/token`' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
+	echo 'echo "Removing temp files..."' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'rm -rf $(WORK_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
+	echo 'echo "...done removing temp files."' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 #if($language == "perl")
 	echo 'export PERL5LIB=$$script_dir/../$(LIB_DIR):$$PATH:$$PERL5LIB' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'cd $$script_dir/../$(TEST_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)

--- a/src/java/us/kbase/templates/module_run_bash.vm.properties
+++ b/src/java/us/kbase/templates/module_run_bash.vm.properties
@@ -1,8 +1,5 @@
 #!/bin/bash
-#set ($ismac = $os_name.toLowerCase().contains("mac"))
-#set ($notmac = !$ismac)
 #set ($iswin = $os_name.toLowerCase().contains("win"))
-#set ($notwin = !$iswin)
 #if ($iswin)
 get_short_path() {
     local td=$(cmd //c for %I in \( "`echo $1 | sed 's/\///'  | sed 's/^\(.\)/\1:/' | tr '/' '\\' 2>/dev/null`" \) do echo %~fsI | tail -n1);
@@ -14,4 +11,4 @@ script_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 #if ($iswin)
 script_dir=$(get_short_path "$script_dir");
 #end
-$script_dir/run_docker.sh run #if($notmac && $notwin)--user $(id -u) #{end}-i -t -v $script_dir/workdir:/kb/module/work test/${module_name.toLowerCase()}:latest bash
+$script_dir/run_docker.sh run -i -t -v $script_dir/workdir:/kb/module/work test/${module_name.toLowerCase()}:latest bash

--- a/src/java/us/kbase/templates/module_run_tests.vm.properties
+++ b/src/java/us/kbase/templates/module_run_tests.vm.properties
@@ -1,8 +1,5 @@
 #!/bin/bash
-#set ($ismac = $os_name.toLowerCase().contains("mac"))
-#set ($notmac = !$ismac)
 #set ($iswin = $os_name.toLowerCase().contains("win"))
-#set ($notwin = !$iswin)
 #if ($iswin)
 get_short_path() {
     local td=$(cmd //c for %I in \( "`echo $1 | sed 's/\///'  | sed 's/^\(.\)/\1:/' | tr '/' '\\' 2>/dev/null`" \) do echo %~fsI | tail -n1);
@@ -25,14 +22,14 @@ else
     else
         mkdir $script_dir/refdata
     fi
-    $script_dir/run_docker.sh run #if($notmac && $notwin)--user $(id -u) #{end}-v $script_dir/workdir:/kb/module/work -v $script_dir/refdata:/data -v $script_dir/../data:/kb/module/data -e "SDK_CALLBACK_URL=$1" test/${module_name.toLowerCase()}:latest init
+    $script_dir/run_docker.sh run -v $script_dir/workdir:/kb/module/work -v $script_dir/refdata:/data -v $script_dir/../data:/kb/module/data -e "SDK_CALLBACK_URL=$1" test/${module_name.toLowerCase()}:latest init
 fi
 if [ -f "$script_dir/refdata/__READY__" ]; then
-    $script_dir/run_docker.sh run #if($notmac && $notwin)--user $(id -u) #{end}-v $script_dir/workdir:/kb/module/work -v $script_dir/refdata:/data:ro -e "SDK_CALLBACK_URL=$1" test/${module_name.toLowerCase()}:latest test
+    $script_dir/run_docker.sh run -v $script_dir/workdir:/kb/module/work -v $script_dir/refdata:/data:ro -e "SDK_CALLBACK_URL=$1" test/${module_name.toLowerCase()}:latest test
 else
     echo "ERROR: __READY__ file is not detected. Reference data initialization wasn't done correctly."
     exit 1
 fi
 #else
-$script_dir/run_docker.sh run #if($notmac && $notwin)--user $(id -u) #{end}-v $script_dir/workdir:/kb/module/work -e "SDK_CALLBACK_URL=$1" test/${module_name.toLowerCase()}:latest test
+$script_dir/run_docker.sh run -v $script_dir/workdir:/kb/module/work -e "SDK_CALLBACK_URL=$1" test/${module_name.toLowerCase()}:latest test
 #end


### PR DESCRIPTION
This removes the -user setting so the containers run as root. As noted, this might generate files in the test_local dir that the user then does not own but only on Linux. Furthermore, these files are perged on each test run by this code here:
https://github.com/kbase/kb_sdk/blob/2c5a6cd346256b28e4b202d4465665e64857f2d4/src/java/us/kbase/mobu/tester/ModuleTester.java#L165-L171