### PR TITLE
Sct-1193

### DIFF
--- a/src/java/us/kbase/templates/module_test_python_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_python_client.vm.properties
@@ -1,19 +1,9 @@
 # -*- coding: utf-8 -*-
-import unittest
-import os  # noqa: F401
-import json  # noqa: F401
+import os
 import time
-import requests
+import unittest
+from configparser import ConfigParser
 
-from os import environ
-try:
-    from ConfigParser import ConfigParser  # py2
-except:
-    from configparser import ConfigParser  # py3
-
-from pprint import pprint  # noqa: F401
-
-from biokbase.workspace.client import Workspace as workspaceService
 from ${module_name}.${module_name}Impl import ${module_name}
 from ${module_name}.${module_name}Server import MethodContext
 from ${module_name}.authclient import KBaseAuth as _KBaseAuth
@@ -21,13 +11,15 @@ from ${module_name}.authclient import KBaseAuth as _KBaseAuth
 #if ($example)
 from AssemblyUtil.AssemblyUtilClient import AssemblyUtil
 #end
+from Workspace.WorkspaceClient import Workspace
+
 
 class ${module_name}Test(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        token = environ.get('KB_AUTH_TOKEN', None)
-        config_file = environ.get('KB_DEPLOYMENT_CONFIG', None)
+        token = os.environ.get('KB_AUTH_TOKEN', None)
+        config_file = os.environ.get('KB_DEPLOYMENT_CONFIG', None)
         cls.cfg = {}
         config = ConfigParser()
         config.read(config_file)
@@ -49,7 +41,7 @@ class ${module_name}Test(unittest.TestCase):
                              }],
                         'authenticated': 1})
         cls.wsURL = cls.cfg['workspace-url']
-        cls.wsClient = workspaceService(cls.wsURL)
+        cls.wsClient = Workspace(cls.wsURL)
         cls.serviceImpl = ${module_name}(cls.cfg)
         cls.scratch = cls.cfg['scratch']
         cls.callback_url = os.environ['SDK_CALLBACK_URL']


### PR DESCRIPTION
This cleans up the import on the python tests by removing unused import and reordering. Most importantly it removes the dependency on the base image workspace in biokbase so that may be removed at a future date