### PR TITLE
Tweak server exception

### DIFF
--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -130,9 +130,9 @@ class JSONRPCServiceCustom(JSONRPCService):
             newerr = JSONServerError()
             newerr.trace = traceback.format_exc()
             if len(e.args) == 1:
-                newerr.data = str(e.args[0])
+                newerr.data = repr(e.args[0])
             else:
-                newerr.data = str(e.args)
+                newerr.data = repr(e.args)
             raise newerr
         return result
 

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -129,11 +129,10 @@ class JSONRPCServiceCustom(JSONRPCService):
             # Exception was raised inside the method.
             newerr = JSONServerError()
             newerr.trace = traceback.format_exc()
-            if isinstance(e.message, str):
-                newerr.data = e.message
+            if len(e.args) == 1:
+                newerr.data = str(e.args[0])
             else:
-                # Some exceptions embed other exceptions as the message
-                newerr.data = repr(e.message)
+                newerr.data = str(e.args)
             raise newerr
         return result
 


### PR DESCRIPTION
If a python3 module is called as a subjob and that module raises an exception a bit of untested code gets called that raises an exception of it's own in python3. The result is a compound exception like this: 
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/suite.py", line 208, in run
    self.setUp()
  File "/usr/lib/python2.7/dist-packages/nose/suite.py", line 291, in setUp
    self.setupContext(ancestor)
  File "/usr/lib/python2.7/dist-packages/nose/suite.py", line 314, in setupContext
    try_run(context, names)
  File "/usr/lib/python2.7/dist-packages/nose/util.py", line 471, in try_run
    return func()
  File "/kb/module/test/phenotype_set_importer_test.py", line 67, in setUpClass
    cls.prepare_data()
  File "/kb/module/test/phenotype_set_importer_test.py", line 92, in prepare_data
    'genome_name': cls.genome_object_name,
  File "/kb/module/lib/GenomeFileUtil/GenomeFileUtilClient.py", line 86, in genbank_to_genome
    job_state = self._check_job(job_id)
  File "/kb/module/lib/GenomeFileUtil/GenomeFileUtilClient.py", line 44, in _check_job
    return self._client._check_job('GenomeFileUtil', job_id)
  File "/kb/module/lib/GenomeFileUtil/baseclient.py", line 216, in _check_job
    return self._call(self.url, service + '._check_job', [job_id])
  File "/kb/module/lib/GenomeFileUtil/baseclient.py", line 183, in _call
    raise ServerError(**err['error'])
ServerError: Unexpected Server Error: 0. An unexpected server error occurred
Traceback (most recent call last):
  File "/kb/module/bin/../lib/GenomeFileUtil/GenomeFileUtilServer.py", line 101, in _call_method
    result = method(ctx, *params)
  File "/kb/module/lib/GenomeFileUtil/GenomeFileUtilImpl.py", line 104, in genbank_to_genome
    result = importer.refactored_import(ctx, params)
  File "/kb/module/lib/GenomeFileUtil/core/GenbankToGenome.py", line 107, in refactored_import
    genome = self.parse_genbank(consolidated_file, params)
  File "/kb/module/lib/GenomeFileUtil/core/GenbankToGenome.py", line 271, in parse_genbank
    self._parse_features(record, params['source'])
  File "/kb/module/lib/GenomeFileUtil/core/GenbankToGenome.py", line 574, in _parse_features
    self.process_cds(_id, feat_seq, in_feature, out_feat)
  File "/kb/module/lib/GenomeFileUtil/core/GenbankToGenome.py", line 761, in process_cds
    raise ValueError(warnings['no_spoof'])
ValueError: Some CDS features in the file do not have a parent gene. Ensure the correct file source is selected, correct the source file or select the 'generate_missing_genes' option.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/kb/module/bin/../lib/GenomeFileUtil/GenomeFileUtilServer.py", line 605, in process_async_cli
    resp = application.rpc_service.call_py(ctx, req)
  File "/kb/module/bin/../lib/GenomeFileUtil/GenomeFileUtilServer.py", line 149, in call_py
    respond = self._handle_request(ctx, request)
  File "/kb/module/bin/../lib/GenomeFileUtil/GenomeFileUtilServer.py", line 187, in _handle_request
    result = self._call_method(ctx, request)
  File "/kb/module/bin/../lib/GenomeFileUtil/GenomeFileUtilServer.py", line 118, in _call_method
    if isinstance(e.message, str):
AttributeError: 'ValueError' object has no attribute 'message'
```

The original error is still legible but users could get confused by the additional traceback. This PR fixes this issue by using the args attribute which is available in 2 and 3.

This is a simple fix but will require a rebuild of the python3 image because kb-sdk is a built-in dependency of the base image. (Chicken, meet Egg)This dependency results from the fact that sdk modules specs are compiled by the dockerfile every time.