### PR TITLE
Sct-1366: Retry on check_job fail in base client

### DIFF
--- a/src/java/us/kbase/templates/baseclient.py
+++ b/src/java/us/kbase/templates/baseclient.py
@@ -11,6 +11,8 @@ import json as _json
 import requests as _requests
 import random as _random
 import os as _os
+import traceback as _traceback
+from requests.exceptions import ConnectionError
 
 try:
     from configparser import ConfigParser as _ConfigParser  # py 3
@@ -26,6 +28,7 @@ import time
 _CT = 'content-type'
 _AJ = 'application/json'
 _URL_SCHEME = frozenset(['http', 'https'])
+_CHECK_JOB_RETRYS = 3
 
 
 def _get_token(user_id, password, auth_svc):
@@ -236,14 +239,22 @@ class BaseClient(object):
         mod, _ = service_method.split('.')
         job_id = self._submit_job(service_method, args, service_ver, context)
         async_job_check_time = self.async_job_check_time
-        while True:
+        check_job_failures = 0
+        while check_job_failures < _CHECK_JOB_RETRYS:
             time.sleep(async_job_check_time)
             async_job_check_time = (async_job_check_time *
                                     self.async_job_check_time_scale_percent /
                                     100.0)
             if async_job_check_time > self.async_job_check_max_time:
                 async_job_check_time = self.async_job_check_max_time
-            job_state = self._check_job(mod, job_id)
+
+            try:
+                job_state = self._check_job(mod, job_id)
+            except ConnectionError:
+                _traceback.print_exc()
+                check_job_failures += 1
+                continue
+
             if job_state['finished']:
                 if not job_state['result']:
                     return

--- a/src/java/us/kbase/templates/module_makefile.vm.properties
+++ b/src/java/us/kbase/templates/module_makefile.vm.properties
@@ -24,7 +24,7 @@ ANT = $(ANT_HOME)/bin/ant
 
 default: compile
 
-all: compile build build-startup-script build-executable-script build-test-script
+all: build build-startup-script build-executable-script build-test-script
 
 compile:
 	kb-sdk compile $(SPEC_FILE) \


### PR DESCRIPTION
This adds logic to retry the _check_job logic if a ConnectionError is raised by requests. This patch seems to work as demonstrated by kb_stringtie and ExpressionUtil modules. 

The other change I am proposing here is to avoid compiling the module on docker build each time. I think it's pretty non intuitive that we commit the compiled code to the repo but that can get out of sync with the actual code run in the docker container because of this step.