### PR TITLE
SCT-1586: Better default KIDL and UI

### DIFF
--- a/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
+++ b/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
@@ -32,8 +32,7 @@ public class ModuleInitializer {
 										"test",
 										"ui",
 										"ui/narrative",
-										"ui/narrative/methods",
-										"ui/narrative/widgets"};
+										"ui/narrative/methods"};
 	
 	public ModuleInitializer(String moduleName, String userName, boolean verbose) {
 		this(moduleName, userName, DEFAULT_LANGUAGE, verbose);
@@ -83,8 +82,8 @@ public class ModuleInitializer {
 		    }
 		}
 		else {
-			subdirList.add("ui/narrative/methods/example_method");
-			subdirList.add("ui/narrative/methods/example_method/img");
+			subdirList.add("ui/narrative/methods/run_" + this.moduleName);
+			subdirList.add("ui/narrative/methods/run_" + this.moduleName + "/img");
 		}
 	
 		// 1. build dir with moduleName
@@ -214,8 +213,8 @@ public class ModuleInitializer {
 					break;
 			}
 		} else {
-			templateFiles.put("module_method_spec_json", Paths.get(moduleDir, "ui", "narrative", "methods", "example_method", "spec.json"));
-			templateFiles.put("module_method_spec_yaml", Paths.get(moduleDir, "ui", "narrative", "methods", "example_method", "display.yaml"));
+			templateFiles.put("module_method_spec_json", Paths.get(moduleDir, "ui", "narrative", "methods", "run_"+this.moduleName, "spec.json"));
+			templateFiles.put("module_method_spec_yaml", Paths.get(moduleDir, "ui", "narrative", "methods", "run_"+this.moduleName, "display.yaml"));
 		}
 
 		for (String templateName : templateFiles.keySet()) {

--- a/src/java/us/kbase/templates/module_method_spec_json.vm.properties
+++ b/src/java/us/kbase/templates/module_method_spec_json.vm.properties
@@ -51,13 +51,14 @@
                 {
                     "narrative_system_variable": "workspace",
                     "target_property": "workspace_name"
-                },
-                {
+                },{
+                    "narrative_system_variable": "workspace_id",
+                    "target_property": "workspace_id"
+                },{
                     "input_parameter": "assembly_input_ref",
                     "target_property": "assembly_input_ref",
                     "target_type_transform": "resolved-ref"
-                },
-                {
+                },{
                     "input_parameter": "min_length",
                     "target_property": "min_length"
                 }
@@ -147,20 +148,21 @@
                 {
                     "narrative_system_variable": "workspace",
                     "target_property": "workspace_name"
-                },
-                {
+                },{
+                    "narrative_system_variable": "workspace_id",
+                    "target_property": "workspace_id"
+                },{
                     "input_parameter": "parameter_1",
                     "target_property": "parameter_1"
                 }
             ],
             "output_mapping": [
                 {
-                "service_method_output_path": [0,"report_name"],
-                "target_property": "report_name"
-                },
-                {
-                "service_method_output_path": [0,"report_ref"],
-                "target_property": "report_ref"
+                    "service_method_output_path": [0,"report_name"],
+                    "target_property": "report_name"
+                },{
+                    "service_method_output_path": [0,"report_ref"],
+                    "target_property": "report_ref"
                 }
             ]
         }

--- a/src/java/us/kbase/templates/module_method_spec_json.vm.properties
+++ b/src/java/us/kbase/templates/module_method_spec_json.vm.properties
@@ -142,29 +142,25 @@
         "service-mapping": {
             "url": "",
             "name": "$module_name",
-            "method": "your_method",
+            "method": "run_$module_name",
             "input_mapping": [
                 {
                     "narrative_system_variable": "workspace",
-                    "target_argument_position": 0
+                    "target_property": "workspace_name"
                 },
                 {
                     "input_parameter": "parameter_1",
-                    "target_argument_position": 1
+                    "target_property": "parameter_1"
                 }
             ],
             "output_mapping": [
                 {
-                    "service_method_output_path": [0],
-                    "target_property": "output"
+                "service_method_output_path": [0,"report_name"],
+                "target_property": "report_name"
                 },
                 {
-                    "input_parameter": "parameter_1",
-                    "target_property": "input"
-                },
-                {
-                    "narrative_system_variable": "workspace",
-                    "target_property": "workspaceName"
+                "service_method_output_path": [0,"report_ref"],
+                "target_property": "report_ref"
                 }
             ]
         }

--- a/src/java/us/kbase/templates/module_method_spec_yaml.vm.properties
+++ b/src/java/us/kbase/templates/module_method_spec_yaml.vm.properties
@@ -98,7 +98,7 @@ screenshots: []
 icon: icon.png
 
 #
-# define a set of similar methods that might be useful to the user
+# define a set of similar apps that might be useful to the user
 #
 suggestions:
     apps:
@@ -106,11 +106,6 @@ suggestions:
             [app1, app2]
         next:
             [app3, app4]
-    methods:
-        related:
-            [method1, method2]
-        next:
-            [method3, method4]
 
 #
 # Configure the display and description of parameters

--- a/src/java/us/kbase/templates/module_typespec.vm.properties
+++ b/src/java/us/kbase/templates/module_typespec.vm.properties
@@ -90,9 +90,9 @@ module ${module_name} {
     } ReportResults;
 
     /*
-        This example function takes accepts any number of parameters and returns results in a KBaseReport
+        This example function accepts any number of parameters and returns results in a KBaseReport
     */
-    funcdef run_${module_name}(UnspecifiedObject params) returns (ReportResults output) authentication required;
+    funcdef run_${module_name}(mapping<string,UnspecifiedObject> params) returns (ReportResults output) authentication required;
 
 #end
 };

--- a/src/java/us/kbase/templates/module_typespec.vm.properties
+++ b/src/java/us/kbase/templates/module_typespec.vm.properties
@@ -84,8 +84,15 @@ module ${module_name} {
     funcdef count_contigs(workspace_name,contigset_id) returns (CountContigsResults) authentication required;
 #end
 #else
+    typedef structure {
+        string report_name;
+        string report_ref;
+    } ReportResults;
+
     /*
-        Insert your typespec information here.
+        This example function takes accepts any number of parameters and returns results in a KBaseReport
     */
+    funcdef run_${module_name}(UnspecifiedObject params) returns (ReportResults output) authentication required;
+
 #end
 };


### PR DESCRIPTION
* Make init have default impl that accepts a param dict and returns report refs. 
* Renames "example_module" to "run_<module_name>"
* Updates UI example to modern equivalent.