### PR TITLE
Add "Hello World" example to basic init

### DIFF
--- a/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
+++ b/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
@@ -175,47 +175,43 @@ public class ModuleInitializer {
                 templateFiles.put("module_method_spec_json", Paths.get(moduleDir, "ui", "narrative", "methods", "count_contigs_in_set", "spec.json"));
                 templateFiles.put("module_method_spec_yaml", Paths.get(moduleDir, "ui", "narrative", "methods", "count_contigs_in_set", "display.yaml"));
             }
-			//templateFiles.put("module_test_perl_client", Paths.get(moduleDir, "test", "test_perl_client.pl"));
-			//templateFiles.put("module_test_python_client", Paths.get(moduleDir, "test", "test_python_client.py"));
-			//templateFiles.put("module_test_java_client", Paths.get(moduleDir, "test", "test_java_client.java"));
-			//templateFiles.put("module_test_all_clients", Paths.get(moduleDir, "test", "test_all_clients.sh"));
-
-			switch(this.language) {
-				// Perl just needs an impl file and a start server script
-				case "perl":
-					//templateFiles.put("module_start_perl_server", Paths.get(moduleDir, "scripts", "start_server.sh"));
-				    // start_server script is now made in Makefile
-					templateFiles.put("module_perl_impl", Paths.get(moduleDir, "lib", this.moduleName, this.moduleName + "Impl.pm"));
-					break;
-				// Python needs some empty __init__.py files and the impl file (Done, see TemplateBasedGenerator.initPyhtonPackages)
-				case "python":
-					initDirectory(Paths.get(moduleDir, "lib", this.moduleName), false);
-					initFile(Paths.get(moduleDir, "lib", this.moduleName, "__init__.py"), false);
-					templateFiles.put("module_python_impl", Paths.get(moduleDir, "lib", this.moduleName, this.moduleName + "Impl.py"));
-					//templateFiles.put("module_start_python_server", Paths.get(moduleDir, "scripts", "start_server.sh"));
-                    // start_server script is now made in Makefile
-					break;
-				case "r":
-                    templateFiles.put("module_r_impl", Paths.get(moduleDir, "lib", this.moduleName, this.moduleName + "Impl.r"));
-                    break;
-				case "java":
-		            File srcDir = new File(moduleDir, "lib/src");
-		            String modulePackage = (String)moduleContext.get("java_package");
-		            String javaModuleName = (String)moduleContext.get("java_module_name");
-		            String javaPackageParent = (String)moduleContext.get("java_package_parent");
-			        File serverJavaFile = new File(srcDir, modulePackage.replace('.', '/') + "/" + javaModuleName + "Server.java");
-			        fillTemplate(moduleContext, "module_java_impl", serverJavaFile.toPath());
-			        JavaTypeGenerator.processSpec(new File(moduleDir, specFile), srcDir, javaPackageParent, true, null, null, null);
-					//templateFiles.put("module_start_java_server", Paths.get(moduleDir, "scripts", "start_server.sh"));
-                    // start_server script is now made in Makefile
-					break;
-				default:
-					break;
-			}
 		} else {
-			templateFiles.put("module_method_spec_json", Paths.get(moduleDir, "ui", "narrative", "methods", "run_"+this.moduleName, "spec.json"));
-			templateFiles.put("module_method_spec_yaml", Paths.get(moduleDir, "ui", "narrative", "methods", "run_"+this.moduleName, "display.yaml"));
-		}
+            templateFiles.put("module_method_spec_json", Paths.get(moduleDir, "ui", "narrative", "methods", "run_"+this.moduleName, "spec.json"));
+            templateFiles.put("module_method_spec_yaml", Paths.get(moduleDir, "ui", "narrative", "methods", "run_"+this.moduleName, "display.yaml"));
+        }
+
+        switch(this.language) {
+            // Perl just needs an impl file and a start server script
+            case "perl":
+                //templateFiles.put("module_start_perl_server", Paths.get(moduleDir, "scripts", "start_server.sh"));
+                // start_server script is now made in Makefile
+                templateFiles.put("module_perl_impl", Paths.get(moduleDir, "lib", this.moduleName, this.moduleName + "Impl.pm"));
+                break;
+            // Python needs some empty __init__.py files and the impl file (Done, see TemplateBasedGenerator.initPyhtonPackages)
+            case "python":
+                initDirectory(Paths.get(moduleDir, "lib", this.moduleName), false);
+                initFile(Paths.get(moduleDir, "lib", this.moduleName, "__init__.py"), false);
+                templateFiles.put("module_python_impl", Paths.get(moduleDir, "lib", this.moduleName, this.moduleName + "Impl.py"));
+                //templateFiles.put("module_start_python_server", Paths.get(moduleDir, "scripts", "start_server.sh"));
+                // start_server script is now made in Makefile
+                break;
+            case "r":
+                templateFiles.put("module_r_impl", Paths.get(moduleDir, "lib", this.moduleName, this.moduleName + "Impl.r"));
+                break;
+            case "java":
+                File srcDir = new File(moduleDir, "lib/src");
+                String modulePackage = (String)moduleContext.get("java_package");
+                String javaModuleName = (String)moduleContext.get("java_module_name");
+                String javaPackageParent = (String)moduleContext.get("java_package_parent");
+                File serverJavaFile = new File(srcDir, modulePackage.replace('.', '/') + "/" + javaModuleName + "Server.java");
+                fillTemplate(moduleContext, "module_java_impl", serverJavaFile.toPath());
+                JavaTypeGenerator.processSpec(new File(moduleDir, specFile), srcDir, javaPackageParent, true, null, null, null);
+                //templateFiles.put("module_start_java_server", Paths.get(moduleDir, "scripts", "start_server.sh"));
+                // start_server script is now made in Makefile
+                break;
+            default:
+                break;
+        }
 
 		for (String templateName : templateFiles.keySet()) {
 			fillTemplate(moduleContext, templateName, templateFiles.get(templateName));
@@ -223,21 +219,17 @@ public class ModuleInitializer {
 		
 		if (example) {
 			// Generated examples require some other SDK dependencies
-			List <String> requiredDependantModules = Arrays.asList("KBaseReport","AssemblyUtil");
-			ClientInstaller clientInstaller = new ClientInstaller(new File(moduleDir), false);
-			for(String dependantModuleName : requiredDependantModules) {
-				clientInstaller.install(
-						this.language,
-						true, // async clients
-						false, // core or sync clients
-						false, // dynamic client
-						"release", //tagVer
-						this.verbose,
-						dependantModuleName,
-						null,
-						null // clientName
-					);
-			}
+            new ClientInstaller(new File(moduleDir), false).install(
+                    this.language,
+                    false, // async clients
+                    true, // core or sync clients
+                    false, // dynamic client
+                    null, //tagVer
+                    this.verbose,
+                    "AssemblyUtil",
+                    null,
+                    null // clientName
+            );
 		}
 		// Let's install fresh workspace client in any cases (we need it at least in tests):
 		new ClientInstaller(new File(moduleDir), false).install(
@@ -251,6 +243,17 @@ public class ModuleInitializer {
                 null,
                 null // clientName
             );
+        new ClientInstaller(new File(moduleDir), false).install(
+                this.language,
+                false, // async clients
+                true, // core or sync clients
+                false, // dynamic client
+                null, //tagVer
+                this.verbose,
+                "KBaseReport",
+                null,
+                null // clientName
+        );
 
 		System.out.println("Done! Your module is available in the " + moduleDir + " directory.");
 		if (example) {

--- a/src/java/us/kbase/templates/module_java_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_java_impl.vm.properties
@@ -1,3 +1,4 @@
+#if ($example)
 package ${java_package};
 
 import java.io.File;
@@ -187,3 +188,49 @@ public class ${java_module_name}Server extends JsonServerServlet {
         }
     }
 }
+#else
+//BEGIN_HEADER
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.net.MalformedURLException;
+
+import kbasereport.CreateParams;
+import kbasereport.KBaseReportClient;
+import kbasereport.Report;
+import kbasereport.ReportInfo;
+import kbasereport.WorkspaceObject;
+import ${java_package}.ReportResults;
+//END_HEADER
+//BEGIN_CLASS_HEADER
+    private final URL callbackURL;
+    private final Path scratch;
+//END_CLASS_HEADER
+//BEGIN_CONSTRUCTOR
+    final String sdkURL = System.getenv("SDK_CALLBACK_URL");
+    try {
+        callbackURL = new URL(sdkURL);
+        System.out.println("Got SDK_CALLBACK_URL " + callbackURL);
+    } catch (MalformedURLException e) {
+        throw new IllegalArgumentException("Invalid SDK callback url: " + sdkURL, e);
+    }
+    scratch = Paths.get(super.config.get("scratch"));
+//END_CONSTRUCTOR
+//BEGIN run_${module_name}
+        final KBaseReportClient kbr = new KBaseReportClient(callbackURL, authPart);
+        kbr.setIsInsecureHttpConnectionAllowed(true);
+        final String ws_name = params.get("workspace_name").asInstance();
+        final String parameter_1 = params.get("parameter_1").asInstance();
+        final ReportInfo report = kbr.create(new CreateParams()
+                                        .withWorkspaceName(ws_name)
+                                        .withReport(new Report()
+                                                .withTextMessage(parameter_1)
+                                                .withObjectsCreated(new java.util.ArrayList<WorkspaceObject>())));
+
+        returnVal = new ReportResults()
+                        .withReportName(report.getName())
+                        .withReportRef(report.getRef());
+
+//END run_${module_name}
+#end

--- a/src/java/us/kbase/templates/module_perl_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_perl_impl.vm.properties
@@ -1,3 +1,4 @@
+#if ($example)
 package ${module_name}::${module_name}Impl;
 use strict;
 use Bio::KBase::Exceptions;
@@ -411,3 +412,38 @@ n_contigs_remaining has a value which is an int
 =cut
 
 1;
+#else
+#BEGIN_HEADER
+use Bio::KBase::AuthToken;
+use installed_clients::KBaseReportClient;
+use Config::IniFiles;
+#END_HEADER
+#BEGIN_CONSTRUCTOR
+    my $config_file = $ENV{ KB_DEPLOYMENT_CONFIG };
+    my $cfg = Config::IniFiles->new(-file=>$config_file);
+    my $scratch = $cfg->val('${module_name}', 'scratch');
+    my $callbackURL = $ENV{ SDK_CALLBACK_URL };
+
+    $self->{scratch} = $scratch;
+    $self->{callbackURL} = $callbackURL;
+#END_CONSTRUCTOR
+#BEGIN run_${module_name}
+    my $repcli = installed_clients::KBaseReportClient->new($self->{callbackURL});
+    my $report = $repcli->create({
+        workspace_name => $params->{workspace_name},
+        report => {
+            text_message => $params->{parameter_1},
+            objects_created => []
+        }
+    });
+
+    my $output = {
+        report_name => $report->{name},
+        report_ref => $report->{ref}
+    };
+#END run_${module_name}
+
+#BEGIN_STATUS
+    $return = {"state" => "OK", "message" => "", "version" => $VERSION, "git_url" => $GIT_URL, "git_commit_hash" => $GIT_COMMIT_HASH};
+#END_STATUS
+#end

--- a/src/java/us/kbase/templates/module_python_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_python_impl.vm.properties
@@ -155,11 +155,8 @@ import os
 from installed_clients.KBaseReportClient import KBaseReport
 #END_HEADER
 #BEGIN_CLASS_HEADER
-    # Class variables and functions can be defined in this block
 #END_CLASS_HEADER
 #BEGIN_CONSTRUCTOR
-# Any configuration parameters that are important should be parsed and
-# saved in the constructor.
         self.callback_url = os.environ['SDK_CALLBACK_URL']
         self.shared_folder = config['scratch']
 #END_CONSTRUCTOR
@@ -171,7 +168,7 @@ from installed_clients.KBaseReportClient import KBaseReport
         output = {
             'report_name': report_info['name'],
             'report_ref': report_info['ref'],
-        };
+        }
 #END run_${module_name}
 #BEGIN_STATUS
         returnVal = {'state': "OK",

--- a/src/java/us/kbase/templates/module_python_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_python_impl.vm.properties
@@ -1,3 +1,4 @@
+#if ($example)
 # -*- coding: utf-8 -*-
 #BEGIN_HEADER
 # The header block is where all import statments should live
@@ -148,3 +149,35 @@ class ${module_name}:
                      'git_commit_hash': self.GIT_COMMIT_HASH}
         #END_STATUS
         return [returnVal]
+#else
+#BEGIN_HEADER
+import os
+from installed_clients.KBaseReportClient import KBaseReport
+#END_HEADER
+#BEGIN_CLASS_HEADER
+    # Class variables and functions can be defined in this block
+#END_CLASS_HEADER
+#BEGIN_CONSTRUCTOR
+# Any configuration parameters that are important should be parsed and
+# saved in the constructor.
+        self.callback_url = os.environ['SDK_CALLBACK_URL']
+        self.shared_folder = config['scratch']
+#END_CONSTRUCTOR
+#BEGIN run_${module_name}
+        report = KBaseReport(self.callback_url)
+        report_info = report.create({'report': {'objects_created':[],
+                                                'text_message': params['parameter_1']},
+                                                'workspace_name': params['workspace_name']})
+        output = {
+            'report_name': report_info['name'],
+            'report_ref': report_info['ref'],
+        };
+#END run_${module_name}
+#BEGIN_STATUS
+        returnVal = {'state': "OK",
+                     'message': "",
+                     'version': self.VERSION,
+                     'git_url': self.GIT_URL,
+                     'git_commit_hash': self.GIT_COMMIT_HASH}
+#END_STATUS
+#end

--- a/src/java/us/kbase/templates/module_test_java_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_java_client.vm.properties
@@ -195,7 +195,7 @@ public class ${java_module_name}ServerTest {
         Map<String, UObject> params = new HashMap<>();
         params.put("workspace_name", new UObject(getWsName()));
         params.put("parameter_1", new UObject("Hello World"));
-        final ReportResults ret = impl.runJavafoo(params, token, getContext());
+        final ReportResults ret = impl.run${java_module_name}(params, token, getContext());
     }
 #end
 }

--- a/src/java/us/kbase/templates/module_test_java_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_java_client.vm.properties
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.HashMap;
 
 import junit.framework.Assert;
 
@@ -24,6 +25,8 @@ import assemblyutil.FastaAssemblyFile;
 import assemblyutil.SaveAssemblyParams;
 import ${java_package}.FilterContigsParams;
 import ${java_package}.FilterContigsResults;
+#else
+import ${java_package}.ReportResults;
 #end
 import ${java_package}.${java_module_name}Server;
 import us.kbase.auth.AuthConfig;
@@ -65,7 +68,7 @@ public class ${java_module_name}ServerTest {
         wsClient.setIsInsecureHttpConnectionAllowed(true); // do we need this?
         callbackURL = new URL(System.getenv("SDK_CALLBACK_URL"));
         scratch = Paths.get(config.get("scratch"));
-        // These lines are necessary because we don't want to start linux syslog bridge service
+        // These lines are necessary because we don"t want to start linux syslog bridge service
         JsonServerSyslog.setStaticUseSyslog(false);
         JsonServerSyslog.setStaticMlogFile(new File(config.get("scratch"), "test.log")
             .getAbsolutePath());
@@ -189,6 +192,10 @@ public class ${java_module_name}ServerTest {
         // Check returned data with
         // Assert.assertEquals(..., ret.getSomeProperty());
         // ... or other JUnit methods.
+        Map<String, UObject> params = new HashMap<>();
+        params.put("workspace_name", new UObject(getWsName()));
+        params.put("parameter_1", new UObject("Hello World"));
+        final ReportResults ret = impl.runJavafoo(params, token, getContext());
     }
 #end
 }

--- a/src/java/us/kbase/templates/module_test_perl_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_perl_client.vm.properties
@@ -102,6 +102,8 @@ eval {
     #
     # Check returned data with
     # ok(ret->{...} eq <expected>, "tested item") or other Test::More methods
+    my $ret = $impl->run_${module_name}({workspace_name => get_ws_name(),
+                                         parameter_1 => "Hello world"});
 #end
 
 };

--- a/src/java/us/kbase/templates/module_test_python_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_python_client.vm.properties
@@ -136,5 +136,6 @@ class ${module_name}Test(unittest.TestCase):
         #
         # Check returned data with
         # self.assertEqual(ret[...], ...) or other unittest methods
-        pass
+        ret = self.getImpl().run_${module_name}(self.getContext(), {'workspace_name': self.getWsName(),
+                                                                    'parameter_1': 'Hello World!'})
 #end


### PR DESCRIPTION
OK, this was more painful than expected but you should be able to initialize Python, Perl and Java modules and run `kb-sdk test` to produce a hello world report.