### PR TITLE
Replace "/run" with "/var/run"

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -4,8 +4,8 @@ if [ "z$1" = "zshell" ] ; then
     exec $DSHELL -l
 elif [ "z$1" = "zsetup" ] ; then
     cat << EOF
-G=\$(docker run -i -v /run/docker.sock:/run/docker.sock --entrypoint ls kbase/kb-sdk -l /run/docker.sock|awk '{print \$4}');
-alias kb-sdk='docker run -it --rm -v \$HOME:\$HOME -u \$(id -u) -w \$(pwd) -v /run/docker.sock:/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL --group-add \$G kbase/kb-sdk'
+G=\$(docker run -i -v /var/run/docker.sock:/var/run/docker.sock --entrypoint ls kbase/kb-sdk -l /var/run/docker.sock|awk '{print \$4}');
+alias kb-sdk='docker run -it --rm -v \$HOME:\$HOME -u \$(id -u) -w \$(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL --group-add \$G kbase/kb-sdk'
 EOF
 elif [ "z$1" = "zgenscript" ] ; then
     cat << EOF
@@ -13,10 +13,10 @@ elif [ "z$1" = "zgenscript" ] ; then
 
 # Cache the group for the docker file
 if [ ! -e \$HOME/.kbsdk.cache ] ; then
-  docker run -i -v /run/docker.sock:/run/docker.sock --entrypoint ls kbase/kb-sdk -l /run/docker.sock|awk '{print \$4}' > \$HOME/.kbsdk.cache
+  docker run -i -v /var/run/docker.sock:/var/run/docker.sock --entrypoint ls kbase/kb-sdk -l /var/run/docker.sock|awk '{print \$4}' > \$HOME/.kbsdk.cache
 fi
 
-exec docker run -it --rm -v \$HOME:\$HOME -u \$(id -u) -w \$(pwd) -v /run/docker.sock:/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL --group-add \$(cat \$HOME/.kbsdk.cache) kbase/kb-sdk \$@
+exec docker run -it --rm -v \$HOME:\$HOME -u \$(id -u) -w \$(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL --group-add \$(cat \$HOME/.kbsdk.cache) kbase/kb-sdk \$@
 EOF
 elif [ "z$1" = "zsdkbase" ] || [ "z$1" = "zpull-base-image" ] ; then
     echo "Pulling and tagging the base image"


### PR DESCRIPTION
People are having problems with the latest sdk image and this entrypoint script.

This script hasn't changed for a long time, so I don't know why it started breaking. It must be the new sdk image not having /run. But this should fix it