### PR TITLE
Fix async py clients

### DIFF
--- a/src/java/us/kbase/mobu/compiler/TemplateBasedGenerator.java
+++ b/src/java/us/kbase/mobu/compiler/TemplateBasedGenerator.java
@@ -157,7 +157,7 @@ public class TemplateBasedGenerator {
         }
         if (pythonClientName != null) {
             String pythonClientPath = fixPath(pythonClientName, ".") + ".py";
-            initPythonPackages(pythonClientPath, output);
+            initPythonPackages(pythonClientPath, output, true);
             Writer pythonClient = output.openWriter(pythonClientPath);
             TemplateFormatter.formatTemplate("python_client", context, pythonClient);
             pythonClient.close();
@@ -201,7 +201,7 @@ public class TemplateBasedGenerator {
         }
         if (pythonServerName != null) {
             String pythonServerPath = fixPath(pythonServerName, ".") + ".py";
-            initPythonPackages(pythonServerPath, output);
+            initPythonPackages(pythonServerPath, output, false);
             Writer pythonServer = output.openWriter(pythonServerPath);
             TemplateFormatter.formatTemplate("python_server", context, pythonServer);
             pythonServer.close();
@@ -318,7 +318,7 @@ public class TemplateBasedGenerator {
         }
     }
     
-    private static void initPythonPackages(String relativePyPath, FileSaver output) throws Exception {
+    private static void initPythonPackages(String relativePyPath, FileSaver output, boolean client) throws Exception {
         String path = relativePyPath;
         while (true) {
             int pos = path.lastIndexOf("/");
@@ -333,9 +333,11 @@ public class TemplateBasedGenerator {
                 output.openWriter(initPath).close();
             }
         }
-        
-        copyResourceFile(relativePyPath, output, "authclient.py");
-        copyResourceFile(relativePyPath, output, "baseclient.py");
+
+        if (client) {
+            copyResourceFile(relativePyPath, output, "authclient.py");
+            copyResourceFile(relativePyPath, output, "baseclient.py");
+        }
     }
 
     private static void copyResourceFile(

--- a/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
+++ b/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
@@ -209,8 +209,8 @@ public class ModuleInitializer {
 			// Generated examples require some other SDK dependencies
             new ClientInstaller(new File(moduleDir), false).install(
                     this.language,
-                    false, // async clients
-                    true, // core or sync clients
+                    true, // async clients
+                    false, // core or sync clients
                     false, // dynamic client
                     null, //tagVer
                     this.verbose,
@@ -233,8 +233,8 @@ public class ModuleInitializer {
             );
         new ClientInstaller(new File(moduleDir), false).install(
                 this.language,
-                false, // async clients
-                true, // core or sync clients
+                true, // async clients
+                false, // core or sync clients
                 false, // dynamic client
                 null, //tagVer
                 this.verbose,

--- a/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
+++ b/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
@@ -71,14 +71,9 @@ public class ModuleInitializer {
 		}
 
 		List<String> subdirList = new ArrayList<String>(Arrays.asList(subdirs));
-		if (example) {
-		    if (this.language.equals("python") || this.language.equals("perl") || this.language.equals("java")) {
-	            subdirList.add("ui/narrative/methods/filter_contigs");
-	            subdirList.add("ui/narrative/methods/filter_contigs/img");
-		    } else {
-		        subdirList.add("ui/narrative/methods/count_contigs_in_set");
-		        subdirList.add("ui/narrative/methods/count_contigs_in_set/img");
-		    }
+		if (example && this.language.equals("r")) {
+			subdirList.add("ui/narrative/methods/count_contigs_in_set");
+			subdirList.add("ui/narrative/methods/count_contigs_in_set/img");
 		}
 		else {
 			subdirList.add("ui/narrative/methods/run_" + this.moduleName);
@@ -165,14 +160,9 @@ public class ModuleInitializer {
             break;
 		}
 		
-		if (example) {
-            if (this.language.equals("python") || this.language.equals("perl") || this.language.equals("java")) {
-                templateFiles.put("module_method_spec_json", Paths.get(moduleDir, "ui", "narrative", "methods", "filter_contigs", "spec.json"));
-                templateFiles.put("module_method_spec_yaml", Paths.get(moduleDir, "ui", "narrative", "methods", "filter_contigs", "display.yaml"));
-            } else {
-                templateFiles.put("module_method_spec_json", Paths.get(moduleDir, "ui", "narrative", "methods", "count_contigs_in_set", "spec.json"));
-                templateFiles.put("module_method_spec_yaml", Paths.get(moduleDir, "ui", "narrative", "methods", "count_contigs_in_set", "display.yaml"));
-            }
+		if (example && this.language.equals("r")) {
+			templateFiles.put("module_method_spec_json", Paths.get(moduleDir, "ui", "narrative", "methods", "count_contigs_in_set", "spec.json"));
+			templateFiles.put("module_method_spec_yaml", Paths.get(moduleDir, "ui", "narrative", "methods", "count_contigs_in_set", "display.yaml"));
 		} else {
             templateFiles.put("module_method_spec_json", Paths.get(moduleDir, "ui", "narrative", "methods", "run_"+this.moduleName, "spec.json"));
             templateFiles.put("module_method_spec_yaml", Paths.get(moduleDir, "ui", "narrative", "methods", "run_"+this.moduleName, "display.yaml"));
@@ -254,13 +244,11 @@ public class ModuleInitializer {
         );
 
 		System.out.println("Done! Your module is available in the " + moduleDir + " directory.");
-		if (example) {
-			System.out.println("Compile and run the example methods with the following inputs:");
-			System.out.println("  cd " + moduleDir);
-			System.out.println("  make          (required after making changes to " + new File(specFile).getName() + ")");
-			System.out.println("  kb-sdk test   (will require setting test user account credentials in test_local/test.cfg)");
-			System.out.println();
-		}
+		System.out.println("Compile and run the example methods with the following inputs:");
+		System.out.println("  cd " + moduleDir);
+		System.out.println("  make          (required after making changes to " + new File(specFile).getName() + ")");
+		System.out.println("  kb-sdk test   (will require setting test user account credentials in test_local/test.cfg)");
+		System.out.println();
 	}
 	
 	/**

--- a/src/java/us/kbase/mobu/initializer/test/InitializerTest.java
+++ b/src/java/us/kbase/mobu/initializer/test/InitializerTest.java
@@ -32,7 +32,6 @@ public class InitializerTest {
 	   "lib",
 	   "ui/narrative",
 	   "ui/narrative/methods/",
-	   "ui/narrative/widgets/",
 	   "lib/README.md",
 	   "test/README.md",
 	   "data/README.md",
@@ -44,9 +43,6 @@ public class InitializerTest {
 	   "Makefile"
 	};
 	private static final String[] EXPECTED_DEFAULT_PATHS = {
-	   "ui/narrative/methods/example_method/img",
-	   "ui/narrative/methods/example_method/spec.json",
-	   "ui/narrative/methods/example_method/display.yaml"
 	};
 	private static List<String> allExpectedDefaultPaths;
 	private static List<String> allExpectedExamplePaths;
@@ -71,8 +67,9 @@ public class InitializerTest {
 	public boolean checkPaths(List<String> pathList, String moduleName) {
 		for (String p : pathList) {
 			File f = Paths.get(tempDir.getAbsolutePath(), moduleName, p).toFile();
+			System.out.println("testing " + p);
 			if (!f.exists()) {
-				System.out.println("Unable to find path: " + f.toString());
+				System.out.println("Unable to find path: " + p);
 				return false;
 			}
 		}

--- a/src/java/us/kbase/mobu/initializer/test/InitializerTest.java
+++ b/src/java/us/kbase/mobu/initializer/test/InitializerTest.java
@@ -21,8 +21,8 @@ public class InitializerTest {
     private static File tempDir = null;
 
 	private static final String SIMPLE_MODULE_NAME = "a_simple_module_for_unit_testing";
-	private static final String EXAMPLE_OLD_METHOD_NAME = "count_contigs_in_set"; 
-    private static final String EXAMPLE_METHOD_NAME = "filter_contigs"; 
+	private static final String EXAMPLE_OLD_METHOD_NAME = "count_contigs_in_set";
+    private static final String EXAMPLE_METHOD_NAME = "run_" + SIMPLE_MODULE_NAME;
 	private static final String USER_NAME = "kbasedev";
 	private static final String[] EXPECTED_PATHS = {
 	   "data",

--- a/src/java/us/kbase/mobu/installer/test/ClientInstallerTest.java
+++ b/src/java/us/kbase/mobu/installer/test/ClientInstallerTest.java
@@ -94,6 +94,9 @@ public class ClientInstallerTest {
         Assert.assertTrue(depsFile.exists());
         String expectedText = "" +
                 "[ {\n" +
+                "  \"module_name\" : \"KBaseReport\",\n" +
+                "  \"type\" : \"core\"\n" +
+                "}, {\n" +
                 "  \"module_name\" : \"onerepotest\",\n" +
                 "  \"type\" : \"sdk\",\n" +
                 "  \"version_tag\" : \"dev\"\n" +

--- a/src/java/us/kbase/mobu/installer/test/ClientInstallerTest.java
+++ b/src/java/us/kbase/mobu/installer/test/ClientInstallerTest.java
@@ -95,7 +95,8 @@ public class ClientInstallerTest {
         String expectedText = "" +
                 "[ {\n" +
                 "  \"module_name\" : \"KBaseReport\",\n" +
-                "  \"type\" : \"core\"\n" +
+                "  \"type\" : \"sdk\",\n" +
+                "  \"version_tag\" : \"release\"\n" +
                 "}, {\n" +
                 "  \"module_name\" : \"onerepotest\",\n" +
                 "  \"type\" : \"sdk\",\n" +

--- a/src/java/us/kbase/templates/module_java_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_java_impl.vm.properties
@@ -30,6 +30,7 @@ import net.sf.jfasta.FASTAFileReader;
 import net.sf.jfasta.impl.FASTAElementIterator;
 import net.sf.jfasta.impl.FASTAFileReaderImpl;
 import net.sf.jfasta.impl.FASTAFileWriter;
+import ${java_package}.ReportResults;
 //END_HEADER
 
 /**
@@ -61,17 +62,17 @@ public class ${java_module_name}Server extends JsonServerServlet {
     }
 
     /**
-     * <p>Original spec-file function name: filter_contigs</p>
+     * <p>Original spec-file function name: run_${module_name}</p>
      * <pre>
      * Filter contigs in a ContigSet by DNA length
      * </pre>
      * @param   params   instance of type {@link ${java_package}.FilterContigsParams FilterContigsParams}
      * @return   instance of type {@link ${java_package}.FilterContigsResults FilterContigsResults}
      */
-    @JsonServerMethod(rpc = "${method_name}.filter_contigs", async=true)
+    @JsonServerMethod(rpc = "${method_name}.run_${module_name}", async=true)
     public FilterContigsResults filterContigs(FilterContigsParams params, AuthToken authPart, RpcContext jsonRpcContext) throws Exception {
         FilterContigsResults returnVal = null;
-        //BEGIN filter_contigs
+        //BEGIN run_${module_name}
         
         // Print statements to stdout/stderr are captured and available as the App log
         System.out.println("Starting filter contigs. Parameters:");
@@ -83,21 +84,21 @@ public class ${java_module_name}Server extends JsonServerServlet {
          * defined in a Narrative App, but advanced users or other SDK developers can call
          * this function directly, so validation is still important.
          */
-        final String workspaceName = params.getWorkspaceName();
+        final String workspaceName = params.get("workspace_name").asInstance();
         if (workspaceName == null || workspaceName.isEmpty()) {
             throw new IllegalArgumentException(
                 "Parameter workspace_name is not set in input arguments");
         }
-        final String assyRef = params.getAssemblyInputRef();
+        final String assyRef = params.get("assembly_input_ref").asInstance();
         if (assyRef == null || assyRef.isEmpty()) {
             throw new IllegalArgumentException(
                     "Parameter assembly_input_ref is not set in input arguments");
         }
-        if (params.getMinLength() == null) {
+        if (!params.containsKey("min_length")) {
             throw new IllegalArgumentException(
-                    "Parameter min_length is not set in input arguments");
+            "Parameter min_length is not set in input arguments");
         }
-        final long minLength = params.getMinLength();
+        final long minLength = params.get("min_length").asInstance();
         if (minLength < 0) {
             throw new IllegalArgumentException("min_length parameter cannot be negative (" +
                     minLength + ")");
@@ -161,16 +162,12 @@ public class ${java_module_name}Server extends JsonServerServlet {
                                 .withRef(newAssyRef)))));
         // Step 6: contruct the output to send back
         
-        returnVal = new FilterContigsResults()
-                .withAssemblyOutput(newAssyRef)
-                .withNInitialContigs(total)
-                .withNContigsRemaining(remaining)
-                .withNContigsRemoved(total - remaining)
+        returnVal = new ReportResults()
                 .withReportName(report.getName())
                 .withReportRef(report.getRef());
 
         System.out.println("returning:\n" + returnVal);
-        //END filter_contigs
+        //END run_${module_name}
         return returnVal;
     }
 

--- a/src/java/us/kbase/templates/module_method_spec_json.vm.properties
+++ b/src/java/us/kbase/templates/module_method_spec_json.vm.properties
@@ -46,7 +46,7 @@
         "service-mapping": {
             "url": "",
             "name":"$module_name",
-            "method": "filter_contigs",
+            "method": "run_$module_name",
             "input_mapping": [
                 {
                     "narrative_system_variable": "workspace",

--- a/src/java/us/kbase/templates/module_perl_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_perl_impl.vm.properties
@@ -6,7 +6,7 @@ use Bio::KBase::Exceptions;
 # http://semver.org 
 our $VERSION = '0.0.1';
 our $GIT_URL = '';
-our $GIT_COMMIT_HASH = 'b711033bc190f2bd70436ecf50ddb211fb8e4990';
+our $GIT_COMMIT_HASH = '';
 
 =head1 NAME
 
@@ -15,7 +15,7 @@ ${module_name}
 =head1 DESCRIPTION
 
 A KBase module: ${module_name}
-This sample module contains one small method - filter_contigs.
+This sample module contains one small method that filters contigs.
 
 =cut
 
@@ -57,57 +57,9 @@ sub new
 
 
 
-=head2 filter_contigs
+=head2 run_${module_name}
 
-  $output = $obj->filter_contigs($params)
-
-=over 4
-
-=item Parameter and return types
-
-=begin html
-
-<pre>
-$params is a ${module_name}.FilterContigsParams
-$output is a ${module_name}.FilterContigsResults
-FilterContigsParams is a reference to a hash where the following keys are defined:
-	assembly_input_ref has a value which is a ${module_name}.assembly_ref
-	workspace_name has a value which is a string
-	min_length has a value which is an int
-assembly_ref is a string
-FilterContigsResults is a reference to a hash where the following keys are defined:
-	report_name has a value which is a string
-	report_ref has a value which is a string
-	assembly_output has a value which is a ${module_name}.assembly_ref
-	n_initial_contigs has a value which is an int
-	n_contigs_removed has a value which is an int
-	n_contigs_remaining has a value which is an int
-
-</pre>
-
-=end html
-
-=begin text
-
-$params is a ${module_name}.FilterContigsParams
-$output is a ${module_name}.FilterContigsResults
-FilterContigsParams is a reference to a hash where the following keys are defined:
-	assembly_input_ref has a value which is a ${module_name}.assembly_ref
-	workspace_name has a value which is a string
-	min_length has a value which is an int
-assembly_ref is a string
-FilterContigsResults is a reference to a hash where the following keys are defined:
-	report_name has a value which is a string
-	report_ref has a value which is a string
-	assembly_output has a value which is a ${module_name}.assembly_ref
-	n_initial_contigs has a value which is an int
-	n_contigs_removed has a value which is an int
-	n_contigs_remaining has a value which is an int
-
-
-=end text
-
-
+  $output = $obj->run_${module_name}($params)
 
 =item Description
 
@@ -120,7 +72,7 @@ Apps that run in the Narrative, your function should have the
 
 =cut
 
-sub filter_contigs
+sub run_${module_name}
 {
     my $self = shift;
     my($params) = @_;
@@ -128,17 +80,17 @@ sub filter_contigs
     my @_bad_arguments;
     (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument \"params\" (value was \"$params\")");
     if (@_bad_arguments) {
-    my $msg = "Invalid arguments passed to filter_contigs:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+    my $msg = "Invalid arguments passed to run_${module_name}:\n" . join("", map { "\t$_\n" } @_bad_arguments);
     Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-                                   method_name => 'filter_contigs');
+                                   method_name => 'run_${module_name}');
     }
 
     my $ctx = $${module_name}::${module_name}Server::CallContext;
     my($output);
-    #BEGIN filter_contigs
+    #BEGIN run_${module_name}
     
     # Print statements to stdout/stderr are captured and available as the App log
-    print("Starting filter contigs method. Parameters:\n");
+    print("Starting run_${module_name} method. Parameters:\n");
     print(Dumper($params) . "\n");
     
     # Step 1 - Parse/examine the parameters and catch any errors
@@ -218,13 +170,13 @@ sub filter_contigs
 
     print("returning: ".Dumper($output)."\n");
     
-    #END filter_contigs
+    #END run_${module_name}
     my @_bad_returns;
     (ref($output) eq 'HASH') or push(@_bad_returns, "Invalid type for return variable \"output\" (value was \"$output\")");
     if (@_bad_returns) {
-    my $msg = "Invalid returns passed to filter_contigs:\n" . join("", map { "\t$_\n" } @_bad_returns);
+    my $msg = "Invalid returns passed to run_${module_name}:\n" . join("", map { "\t$_\n" } @_bad_returns);
     Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-                                   method_name => 'filter_contigs');
+                                   method_name => 'run_${module_name}');
     }
     return($output);
 }
@@ -270,146 +222,6 @@ sub status {
     #END_STATUS
     return($return);
 }
-
-=head1 TYPES
-
-
-
-=head2 assembly_ref
-
-=over 4
-
-
-
-=item Description
-
-A 'typedef' allows you to provide a more specific name for
-a type.  Built-in primitive types include 'string', 'int',
-'float'.  Here we define a type named assembly_ref to indicate
-a string that should be set to a KBase ID reference to an
-Assembly data object.
-
-
-=item Definition
-
-=begin html
-
-<pre>
-a string
-</pre>
-
-=end html
-
-=begin text
-
-a string
-
-=end text
-
-=back
-
-
-
-=head2 FilterContigsParams
-
-=over 4
-
-
-
-=item Description
-
-A 'typedef' can also be used to define compound or container
-objects, like lists, maps, and structures.  The standard KBase
-convention is to use structures, as shown here, to define the
-input and output of your function.  Here the input is a
-reference to the Assembly data object, a workspace to save
-output, and a length threshold for filtering.
-
-To define lists and maps, use a syntax similar to C++ templates
-to indicate the type contained in the list or map.  For example:
-
-    list <string> list_of_strings;
-    mapping <string, int> map_of_ints;
-
-
-=item Definition
-
-=begin html
-
-<pre>
-a reference to a hash where the following keys are defined:
-assembly_input_ref has a value which is a ${module_name}.assembly_ref
-workspace_name has a value which is a string
-min_length has a value which is an int
-
-</pre>
-
-=end html
-
-=begin text
-
-a reference to a hash where the following keys are defined:
-assembly_input_ref has a value which is a ${module_name}.assembly_ref
-workspace_name has a value which is a string
-min_length has a value which is an int
-
-
-=end text
-
-=back
-
-
-
-=head2 FilterContigsResults
-
-=over 4
-
-
-
-=item Description
-
-Here is the definition of the output of the function.  The output
-can be used by other SDK modules which call your code, or the output
-visualizations in the Narrative.  'report_name' and 'report_ref' are
-special output fields- if defined, the Narrative can automatically
-render your Report.
-
-
-=item Definition
-
-=begin html
-
-<pre>
-a reference to a hash where the following keys are defined:
-report_name has a value which is a string
-report_ref has a value which is a string
-assembly_output has a value which is a ${module_name}.assembly_ref
-n_initial_contigs has a value which is an int
-n_contigs_removed has a value which is an int
-n_contigs_remaining has a value which is an int
-
-</pre>
-
-=end html
-
-=begin text
-
-a reference to a hash where the following keys are defined:
-report_name has a value which is a string
-report_ref has a value which is a string
-assembly_output has a value which is a ${module_name}.assembly_ref
-n_initial_contigs has a value which is an int
-n_contigs_removed has a value which is an int
-n_contigs_remaining has a value which is an int
-
-
-=end text
-
-=back
-
-
-
-=cut
 
 1;
 #else

--- a/src/java/us/kbase/templates/module_python_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_python_impl.vm.properties
@@ -46,13 +46,13 @@ class ${module_name}:
         #END_CONSTRUCTOR
         pass
 
-    def filter_contigs(self, ctx, params):
+    def run_${module_name}(self, ctx, params):
         # ctx is the context object
         # return variables are: returnVal
-        #BEGIN filter_contigs
+        #BEGIN run_${module_name}
 
         # Print statements to stdout/stderr are captured and available as the App log
-        print('Starting Filter Contigs function. Params=')
+        print('Starting run_${module_name} function. Params=')
         pprint(params)
 
         # Step 1 - Parse/examine the parameters and catch any errors
@@ -130,12 +130,12 @@ class ${module_name}:
                   }
         print('returning:' + pformat(output))
                 
-        #END filter_contigs
+        #END run_${module_name}
         
 
         # At some point might do deeper type checking...
         if not isinstance(output, dict):
-            raise ValueError('Method filter_contigs return value ' +
+            raise ValueError('Method run_${module_name} return value ' +
                              'output is not type dict as required.')
         # return the results
         return [output]

--- a/src/java/us/kbase/templates/module_test_java_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_java_client.vm.properties
@@ -23,8 +23,6 @@ import us.kbase.common.service.ServerException;
 import assemblyutil.AssemblyUtilClient;
 import assemblyutil.FastaAssemblyFile;
 import assemblyutil.SaveAssemblyParams;
-import ${java_package}.FilterContigsParams;
-import ${java_package}.FilterContigsResults;
 #else
 import ${java_package}.ReportResults;
 #end
@@ -122,7 +120,7 @@ public class ${java_module_name}ServerTest {
     }
     
     @Test
-    public void testFilterContigsOk() throws Exception {
+    public void test_run${java_module_name}_ok() throws Exception {
         // First load a test FASTA file as an KBase Assembly
         final String fastaContent = ">seq1 something something asdf\n" +
                                     "agcttttcat\n" +
@@ -134,23 +132,21 @@ public class ${java_module_name}ServerTest {
         final String ref = loadFASTA(scratch.resolve("test1.fasta"), "TestAssembly", fastaContent);
         
         // second, call the implementation
-        final FilterContigsResults ret = impl.filterContigs(new FilterContigsParams()
-                .withWorkspaceName(getWsName())
-                .withAssemblyInputRef(ref)
-                .withMinLength(10L),
-                token, getContext());
-        
-        // validate the returned data
-        Assert.assertEquals(3L, (long)ret.getNInitialContigs());
-        Assert.assertEquals(1L, (long)ret.getNContigsRemoved());
-        Assert.assertEquals(2L, (long)ret.getNContigsRemaining());
+        Map<String, UObject> params = new HashMap<>();
+        params.put("workspace_name", new UObject(getWsName()));
+        params.put("assembly_input_ref", new UObject(ref));
+        params.put("min_length", new UObject(10L));
+        impl.run${java_module_name}(params, token, getContext());
+
     }
     
     @Test
-    public void test_filter_contigs_err1() throws Exception {
+    public void test_run${java_module_name}_err1() throws Exception {
         try {
-            impl.filterContigs(new FilterContigsParams().withWorkspaceName(getWsName())
-                .withAssemblyInputRef("fake/fake/1"), token, getContext());
+            Map<String, UObject> params = new HashMap<>();
+            params.put("workspace_name", new UObject(getWsName()));
+            params.put("assembly_input_ref", new UObject("fake/fake/1"));
+            impl.run${java_module_name}(params, token, getContext());
             Assert.fail("Error is expected above");
         } catch (IllegalArgumentException ex) {
             Assert.assertEquals("Parameter min_length is not set in input arguments",
@@ -159,10 +155,13 @@ public class ${java_module_name}ServerTest {
     }
     
     @Test
-    public void test_filter_contigs_err2() throws Exception {
+    public void test_run${java_module_name}_err2() throws Exception {
         try {
-            impl.filterContigs(new FilterContigsParams().withWorkspaceName(getWsName())
-                .withAssemblyInputRef("fake/fake/1").withMinLength(-10L), token, getContext());
+            Map<String, UObject> params = new HashMap<>();
+            params.put("workspace_name", new UObject(getWsName()));
+            params.put("assembly_input_ref", new UObject("fake/fake/1"));
+            params.put("min_length", new UObject(-10L));
+            impl.run${java_module_name}(params, token, getContext());
             Assert.fail("Error is expected above");
         } catch (IllegalArgumentException ex) {
             Assert.assertEquals("min_length parameter cannot be negative (-10)", ex.getMessage());
@@ -170,10 +169,13 @@ public class ${java_module_name}ServerTest {
     }
     
     @Test
-    public void test_filter_contigs_err3() throws Exception {
+    public void test_run${java_module_name}_err3() throws Exception {
         try {
-            impl.filterContigs(new FilterContigsParams().withWorkspaceName(getWsName())
-                .withAssemblyInputRef("fake").withMinLength(10L), token, getContext());
+            Map<String, UObject> params = new HashMap<>();
+            params.put("workspace_name", new UObject(getWsName()));
+            params.put("assembly_input_ref", new UObject("fake"));
+            params.put("min_length", new UObject(10L));
+            impl.run${java_module_name}(params, token, getContext());
             Assert.fail("Error is expected above");
         } catch (ServerException ex) {
             Assert.assertEquals("Error on ObjectSpecification #1: Illegal number of separators " +

--- a/src/java/us/kbase/templates/module_test_perl_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_perl_client.vm.properties
@@ -62,7 +62,7 @@ eval {
     my $ref = load_fasta($scratch . "/test1.fasta", "TestAssembly", $fastaContent);
 
     # Second, call the implementation
-    my $ret = $impl->filter_contigs({workspace_name => get_ws_name(),
+    my $ret = $impl->run_${module_name}({workspace_name => get_ws_name(),
                                      assembly_input_ref => $ref,
                                      min_length => 10});
 
@@ -73,21 +73,21 @@ eval {
 
     $@ = '';
     eval { 
-        $impl->filter_contigs({workspace_name => get_ws_name(),
+        $impl->run_${module_name}({workspace_name => get_ws_name(),
                                assembly_input_ref=>"fake",
                                min_length => 10});
     };
     like($@, qr#separators / in object reference fake#);
     
     eval { 
-        $impl->filter_contigs({workspace_name => get_ws_name(),
+        $impl->run_${module_name}({workspace_name => get_ws_name(),
                                assembly_input_ref => "fake",
                                min_length => -10});
     };
     like($@, qr/min_length parameter cannot be negative/);
     
     eval {
-        $impl->filter_contigs({workspace_name => get_ws_name(),
+        $impl->run_${module_name}({workspace_name => get_ws_name(),
                                assembly_input_ref => "fake"});
     };
     like($@, qr/Parameter min_length is not set in input arguments/);

--- a/src/java/us/kbase/templates/module_test_python_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_python_client.vm.properties
@@ -84,7 +84,7 @@ class ${module_name}Test(unittest.TestCase):
         return assembly_ref
 
     # NOTE: According to Python unittest naming rules test method names should start from 'test'. # noqa
-    def test_filter_contigs_ok(self):
+    def test_run_${module_name}_ok(self):
 
         # First load a test FASTA file as an KBase Assembly
         fasta_content = '>seq1 something soemthing asdf\n' \
@@ -99,7 +99,7 @@ class ${module_name}Test(unittest.TestCase):
                                             fasta_content)
 
         # Second, call your implementation
-        ret = self.getImpl().filter_contigs(self.getContext(),
+        ret = self.getImpl().run_${module_name}(self.getContext(),
                                             {'workspace_name': self.getWsName(),
                                              'assembly_input_ref': assembly_ref,
                                              'min_length': 10
@@ -110,17 +110,17 @@ class ${module_name}Test(unittest.TestCase):
         self.assertEqual(ret[0]['n_contigs_removed'], 1)
         self.assertEqual(ret[0]['n_contigs_remaining'], 2)
 
-    def test_filter_contigs_err1(self):
+    def test_run_${module_name}_err1(self):
         with self.assertRaises(ValueError) as errorContext:
-            self.getImpl().filter_contigs(self.getContext(),
+            self.getImpl().run_${module_name}(self.getContext(),
                                           {'workspace_name': self.getWsName(),
                                            'assembly_input_ref': '1/fake/3',
                                            'min_length': '-10'})
         self.assertIn('min_length parameter cannot be negative', str(errorContext.exception))
 
-    def test_filter_contigs_err2(self):
+    def test_run_${module_name}_err2(self):
         with self.assertRaises(ValueError) as errorContext:
-            self.getImpl().filter_contigs(self.getContext(),
+            self.getImpl().run_${module_name}(self.getContext(),
                                           {'workspace_name': self.getWsName(),
                                            'assembly_input_ref': '1/fake/3',
                                            'min_length': 'ten'})

--- a/src/java/us/kbase/templates/module_typespec.vm.properties
+++ b/src/java/us/kbase/templates/module_typespec.vm.properties
@@ -1,68 +1,12 @@
 /*
 A KBase module: ${module_name}
 #if ($example)
-This sample module contains one small method - filter_contigs.
+This sample module contains one small method that filters contigs.
 #end
 */
 
 module ${module_name} {
-#if ($example)
-#if($language == "python" || $language == "java" || $language == "perl")
-    /* 
-        A 'typedef' allows you to provide a more specific name for
-        a type.  Built-in primitive types include 'string', 'int',
-        'float'.  Here we define a type named assembly_ref to indicate
-        a string that should be set to a KBase ID reference to an
-        Assembly data object.
-    */
-    typedef string assembly_ref;
-
-    /*
-        A 'typedef' can also be used to define compound or container
-        objects, like lists, maps, and structures.  The standard KBase
-        convention is to use structures, as shown here, to define the
-        input and output of your function.  Here the input is a
-        reference to the Assembly data object, a workspace to save
-        output, and a length threshold for filtering.
-
-        To define lists and maps, use a syntax similar to C++ templates
-        to indicate the type contained in the list or map.  For example:
-
-            list <string> list_of_strings;
-            mapping <string, int> map_of_ints;
-    */
-    typedef structure {
-        assembly_ref assembly_input_ref;
-        string workspace_name;
-        int min_length;
-    } FilterContigsParams;
-
-
-    /*
-        Here is the definition of the output of the function.  The output
-        can be used by other SDK modules which call your code, or the output
-        visualizations in the Narrative.  'report_name' and 'report_ref' are
-        special output fields- if defined, the Narrative can automatically
-        render your Report.
-    */
-    typedef structure {
-        string report_name;
-        string report_ref;
-        assembly_ref assembly_output;
-        int n_initial_contigs;
-        int n_contigs_removed;
-        int n_contigs_remaining;
-    } FilterContigsResults;
-    
-    /*
-        The actual function is declared using 'funcdef' to specify the name
-        and input/return arguments to the function.  For all typical KBase
-        Apps that run in the Narrative, your function should have the 
-        'authentication required' modifier.
-    */
-    funcdef filter_contigs(FilterContigsParams params)
-        returns (FilterContigsResults output) authentication required;
-#else
+#if($language == "r" && $example)
     /*
         A string representing a ContigSet id.
     */
@@ -82,7 +26,6 @@ module ${module_name} {
         contigset_id - the ContigSet to count.
     */
     funcdef count_contigs(workspace_name,contigset_id) returns (CountContigsResults) authentication required;
-#end
 #else
     typedef structure {
         string report_name;

--- a/src/java/us/kbase/templates/python_client.vm.properties
+++ b/src/java/us/kbase/templates/python_client.vm.properties
@@ -12,12 +12,9 @@ from __future__ import print_function
 try:
     # baseclient and this client are in a package
     from .baseclient import BaseClient as _BaseClient  # @UnusedImport
-except:
+except ImportError:
     # no they aren't
     from baseclient import BaseClient as _BaseClient  # @Reimport
-#if( $any_async || $async_version )
-import time
-#end
 #foreach( $module in $modules )
 
 
@@ -51,80 +48,35 @@ class ${module.module_name}(object):
             async_job_check_time_scale_percent=async_job_check_time_scale_percent,
             async_job_check_max_time_ms=async_job_check_max_time_ms#{end}#if($dynserv_ver),
             lookup_url=True#{end})
-#if($any_async || $async_version)
-
-    def _check_job(self, job_id):
-        return self._client._check_job('${module.module_name}', job_id)
-#end
 #set( $status_in_kidl = false )
 #foreach($method in $module.methods)
 #if( ${method.name} == "status" )
 #set( $status_in_kidl = true )
 #end
 #set($comma_args = "#if($method.arg_count>0), ${method.args}#{else}#{end}")
+
+    def ${method.name}(self${comma_args}, context=None):
+#if( $method.py_doc_lines.size() > 0 )
+        """
+#foreach( $docline in $method.py_doc_lines )
+        ${docline}
+#end
+        """
+#end
 #if($method.async || $async_version)
-
-    def _${method.name}_submit(self${comma_args}, context=None):
-        return self._client._submit_job(
-             '${module.module_name}.${method.name}', [${method.args}],
-             self._service_ver, context)
-
-    def ${method.name}(self${comma_args}, context=None):
-#if( $method.py_doc_lines.size() > 0 )
-        """
-#foreach( $docline in $method.py_doc_lines )
-        ${docline}
-#end
-        """
-#end
-        job_id = self._${method.name}_submit(${method.args}#if($method.arg_count>0), #{end}context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-#if( $method.ret_count == 1 )
-                return job_state['result'][0]
-#elseif( $method.ret_count > 1 )
-                return job_state['result']
+        return self._client.run_job('${module.module_name}.${method.name}',
+                                    [${method.args}], self._service_ver, context)
 #else
-                return
-#end
-#else## of if-async
-
-    def ${method.name}(self${comma_args}, context=None):
-#if( $method.py_doc_lines.size() > 0 )
-        """
-#foreach( $docline in $method.py_doc_lines )
-        ${docline}
-#end
-        """
-#end
-        return self._client.call_method(
-            '${module.module_name}.${method.name}',
-            [${method.args}], self._service_ver, context)
+        return self._client.call_method('${module.module_name}.${method.name}',
+                                        [${method.args}], self._service_ver, context)
 #end## of if-async
 #end## of foreach method
 #if( !$status_in_kidl )
 #if( $async_version )
 
     def status(self, context=None):
-        job_id = self._client._submit_job('${module.module_name}.status', 
-            [], self._service_ver, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
+        return self._client.run_job('${module.module_name}.status',
+                                    [], self._service_ver, context)
 #else## of if-status-async
 
     def status(self, context=None):


### PR DESCRIPTION
*Merge #339 to clean up the diff*

Essentially this removes duplicate logic from `baseclient.run_job` that was being used in each module specific python client. This has the added benefit of actually incorporating the exception catching I built for check_job. I also switched KBaseReport and AssemblyUtils clients that are generated on module init to be async client rather than core. (Bad copy paste, Sorry!)