### PR TITLE
fix python3 import

### DIFF
--- a/lib/biokbase/log.py
+++ b/lib/biokbase/log.py
@@ -74,7 +74,10 @@ import inspect as _inspect
 import os as _os
 import getpass as _getpass
 import warnings as _warnings
-from ConfigParser import ConfigParser as _ConfigParser
+try:
+    from ConfigParser import ConfigParser as _ConfigParser
+except ImportError:
+    from configparser import ConfigParser as _ConfigParser
 import time
 
 MLOG_ENV_FILE = 'MLOG_CONFIG_FILE'


### PR DESCRIPTION
@JamesJeffryes @jayrbolton 
Hi guys,
ConfigParser was renamed to configparser in Python3
https://docs.python.org/2/library/configparser.html#module-ConfigParser