### PR TITLE
make generated python code pep8 compliant

### DIFF
--- a/src/java/us/kbase/mobu/compiler/PrevCodeParser.java
+++ b/src/java/us/kbase/mobu/compiler/PrevCodeParser.java
@@ -25,7 +25,7 @@ public class PrevCodeParser {
     
     public static HashMap<String, String> parsePrevCode(File implFile, String commentPrefix,
             List<String> funcs, boolean withClassHeader) throws IOException, ParseException {
-        commentPrefix = Pattern.quote(commentPrefix);
+        commentPrefix = Pattern.quote(commentPrefix) + "[ ]?";
         Pattern PAT_HEADER = Pattern.compile(".*" + commentPrefix + 
                 "BEGIN_HEADER\n(.*\n)?[ \t]*" + commentPrefix + "END_HEADER\n.*", Pattern.DOTALL);
         Pattern PAT_CLASS_HEADER = Pattern.compile(".*" + commentPrefix + 

--- a/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
+++ b/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
@@ -153,22 +153,22 @@ public class DockerClientServerTester {
     protected File initPython(String moduleName) throws Exception {
         File moduleDir = new File(moduleName);
         String implInit = "" +
-                "# BEGIN_HEADER\n" +
-                "# END_HEADER\n" +
+                "#BEGIN_HEADER\n" +
+                "#END_HEADER\n" +
                 "\n" +
-                "    # BEGIN_CLASS_HEADER\n" +
-                "    # END_CLASS_HEADER\n" +
+                "    #BEGIN_CLASS_HEADER\n" +
+                "    #END_CLASS_HEADER\n" +
                 "\n" +
-                "        # BEGIN_CONSTRUCTOR\n" +
-                "        # END_CONSTRUCTOR\n" +
+                "        #BEGIN_CONSTRUCTOR\n" +
+                "        #END_CONSTRUCTOR\n" +
                 "\n" +
-                "        # BEGIN run_test\n" +
+                "        #BEGIN run_test\n" +
                 "        returnVal = input\n" +
-                "        # END run_test\n" +
+                "        #END run_test\n" +
                 "\n" +
-                "        # BEGIN throw_error\n" +
+                "        #BEGIN throw_error\n" +
                 "        raise ValueError(input)\n" +
-                "        # END throw_error\n";
+                "        #END throw_error\n";
         File implFile = new File(moduleDir, "lib/" + moduleName + "/" + 
                 moduleName + "Impl.py");
         init("python", moduleName, implFile, implInit);

--- a/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
+++ b/src/java/us/kbase/mobu/initializer/test/DockerClientServerTester.java
@@ -153,22 +153,22 @@ public class DockerClientServerTester {
     protected File initPython(String moduleName) throws Exception {
         File moduleDir = new File(moduleName);
         String implInit = "" +
-                "#BEGIN_HEADER\n" +
-                "#END_HEADER\n" +
+                "# BEGIN_HEADER\n" +
+                "# END_HEADER\n" +
                 "\n" +
-                "    #BEGIN_CLASS_HEADER\n" +
-                "    #END_CLASS_HEADER\n" +
+                "    # BEGIN_CLASS_HEADER\n" +
+                "    # END_CLASS_HEADER\n" +
                 "\n" +
-                "        #BEGIN_CONSTRUCTOR\n" +
-                "        #END_CONSTRUCTOR\n" +
+                "        # BEGIN_CONSTRUCTOR\n" +
+                "        # END_CONSTRUCTOR\n" +
                 "\n" +
-                "        #BEGIN run_test\n" +
+                "        # BEGIN run_test\n" +
                 "        returnVal = input\n" +
-                "        #END run_test\n" +
+                "        # END run_test\n" +
                 "\n" +
-                "        #BEGIN throw_error\n" +
+                "        # BEGIN throw_error\n" +
                 "        raise ValueError(input)\n" +
-                "        #END throw_error\n";
+                "        # END throw_error\n";
         File implFile = new File(moduleDir, "lib/" + moduleName + "/" + 
                 moduleName + "Impl.py");
         init("python", moduleName, implFile, implInit);

--- a/src/java/us/kbase/templates/python_impl.vm.properties
+++ b/src/java/us/kbase/templates/python_impl.vm.properties
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-#BEGIN_HEADER
-${module.py_module_header}#END_HEADER
+# BEGIN_HEADER
+${module.py_module_header}# END_HEADER
 #set( $specToPy = {} )
 #set( $void = $specToPy.put("list", "list") )
 #set( $void = $specToPy.put("tuple", "list") )
@@ -31,14 +31,14 @@ class ${module.module_name}:
     GIT_URL = "${module.git_url}"
     GIT_COMMIT_HASH = "${module.git_commit_hash}"
 
-    #BEGIN_CLASS_HEADER
-${module.py_module_class_header}    #END_CLASS_HEADER
+    # BEGIN_CLASS_HEADER
+${module.py_module_class_header}    # END_CLASS_HEADER
 
     # config contains contents of config file in a hash or None if it couldn't
     # be found
     def __init__(self, config):
-        #BEGIN_CONSTRUCTOR
-${module.py_module_constructor}        #END_CONSTRUCTOR
+        # BEGIN_CONSTRUCTOR
+${module.py_module_constructor}        # END_CONSTRUCTOR
         pass
 
 #set( $status_in_kidl = false )
@@ -74,8 +74,8 @@ ${module.py_module_constructor}        #END_CONSTRUCTOR
 #if( $method.ret_count > 0 )
         # return variables are: $display.join($retlist, ", ")
 #end
-        #BEGIN ${method.name}
-${method.py_user_code}        #[[#END]]# ${method.name}
+        # BEGIN ${method.name}
+${method.py_user_code}        #[[# END]]# ${method.name}
 #if( $method.ret_count > 0 )
 
         # At some point might do deeper type checking...
@@ -83,8 +83,9 @@ ${method.py_user_code}        #[[#END]]# ${method.name}
 #set( $spectype = $ret.baretype )
 #set( $type = $specToPy.get($spectype) )
         if not isinstance(${ret.name}, ${type}):
-            raise ValueError('Method ${method.name} return value ' +
-                             '${ret.name} is not type ${type} as required.')
+            raise ValueError('Method ${method.name} ' +
+                             'return value ${ret.name} ' +
+                             'is not type ${type} as required.')
 #end
         # return the results
         return [$display.join($retlist, ', ')]
@@ -93,8 +94,9 @@ ${method.py_user_code}        #[[#END]]# ${method.name}
 #end
 #end
 #if( !$status_in_kidl )
+
     def status(self, ctx):
-        #BEGIN_STATUS
+        # BEGIN_STATUS
 #if( ${module.py_module_status} )
 ${module.py_module_status}#else
         returnVal = {'state': "OK",
@@ -103,6 +105,6 @@ ${module.py_module_status}#else
                      'git_url': self.GIT_URL,
                      'git_commit_hash': self.GIT_COMMIT_HASH}
 #end
-        #END_STATUS
+        # END_STATUS
         return [returnVal]
 #end

--- a/src/java/us/kbase/templates/python_server.vm.properties
+++ b/src/java/us/kbase/templates/python_server.vm.properties
@@ -51,6 +51,7 @@ def get_config():
         retconfig[nameval[0]] = nameval[1]
     return retconfig
 
+
 config = get_config()
 
 #set( $specToPy = {} )
@@ -146,12 +147,6 @@ class JSONRPCServiceCustom(JSONRPCService):
         debugging purposes.
         """
         rdata = jsondata
-        # we already deserialize the json string earlier in the server code, no
-        # need to do it again
-#        try:
-#            rdata = json.loads(jsondata)
-#        except ValueError:
-#            raise ParseError
 
         # set some default values for error handling
         request = self._get_default_vals()
@@ -526,6 +521,7 @@ class Application(object):
                         60)
         return "%s%+02d:%02d" % (dtnow.isoformat(), hh, mm)
 
+
 application = Application()
 
 # This is the uwsgi application dictionary. On startup uwsgi will look
@@ -639,6 +635,7 @@ def process_async_cli(input_file_path, output_file_path, token):
         f.write(json.dumps(resp, cls=JSONObjectEncoder))
     return exit_code
 
+
 if __name__ == "__main__":
     if (len(sys.argv) >= 3 and len(sys.argv) <= 4 and
             os.path.isfile(sys.argv[1])):
@@ -668,7 +665,3 @@ if __name__ == "__main__":
             assert False, "unhandled option"
 
     start_server(host=host, port=port)
-#    print("Listening on port %s" % port)
-#    httpd = make_server( host, port, application)
-#
-#    httpd.serve_forever()


### PR DESCRIPTION
The primary functional changes are in the implementation and server template files, simply making  the resulting python code pep8 compliant. 

The primary change, numerically, is that the template marker comments did not have a space between the comment start (#) and the first non-whitespace character. Empty line rules were the second most numerous offense.
An adjustment was required to to the parser responsible for the impl file so that it can recognize both the old invalid comment markers, as well as properly formatted ones. Without this change the pep8 compliant impl file would trigger an error in kb-sdk.
No tests were added, nor were tests run successfully in preparation of this PR. Tests appear to be either broken or difficult to set up correctly, and I did not have time to address this. 
I've used the resulting changes successfully on a couple of projects.

There is more to do.
E.g. src/java/us/kbase/templates/module_python_impl.vm.properties is responsible for generating the initial impl file (and example impl file). The generated impl file is not just pep8 non-compliant but also quite broken and non-functional. Fortunately, running "make" in the module after it is created will rewrite the impl file correctly and install the otherwise missing server file. The module initialization process needs a refactor to ensure that the initial module is good, but that is beyond pep8 compliance and out of scope for the work in this PR.

Also, tests should be fixed or at least fully documented, and test cases adjusted, and pep8/flake8 tests added to ensure the generated code is compliant.