### PR TITLE
Update Dockerfile

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -6,7 +6,12 @@ platform.  Modules include all code, specification files, and
 documentation needed to define and run a set of methods
 in the KBase Narrative interface.
 
-VERSION: 1.2.2 (Released 06/xx/2020)
+VERSION: 1.2.3 (Released 06/2020)
+------------------------------------
+NEW FEATURES:
+- updated kb-sdk Dockerfile to use Java 8, the most recent Docker engine, and Ubuntu 20.04.
+
+VERSION: 1.2.2 (Released 06/2020)
 ------------------------------------
 NEW FEATURES:
 - kb-sdk version reports the build time and date of the instance

--- a/src/java/us/kbase/mobu/ModuleBuilder.java
+++ b/src/java/us/kbase/mobu/ModuleBuilder.java
@@ -49,7 +49,7 @@ public class ModuleBuilder {
     public static final String GLOBAL_SDK_HOME_ENV_VAR = "KB_SDK_HOME";
     public static final String DEFAULT_METHOD_STORE_URL = "https://appdev.kbase.us/services/narrative_method_store/rpc";
 
-    public static final String VERSION = "1.2.2";
+    public static final String VERSION = "1.2.3";
 
     public static void main(String[] args) throws Exception {
 


### PR DESCRIPTION
Edit the dockerfile that `kb-sdk` runs on to update the Docker engine, bump the Java version to Java 8, and bump the Ubuntu release to 20.04.

N.b. the GitHub actions will not run until someone with write access to the repo adds a KBASE_TEST_TOKEN secret under https://github.com/kbase/kb_sdk/settings/secrets

Tests all pass: https://github.com/ialarmedalien/kb_sdk/actions/runs/143963328