### PR TITLE
Adding kb-sdk image build and upload to Dockerhub to GitHub actions

### DIFF
--- a/.github/workflows/kb_sdk-actions.yml
+++ b/.github/workflows/kb_sdk-actions.yml
@@ -134,3 +134,33 @@ jobs:
         with:
           name: kbaseapp-${{ matrix.app }}-${{ matrix.os }}
           path: kbase_app
+
+  dockerhub_upload:
+    runs-on: ubuntu-latest
+    if: |
+      (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') &&
+      github.event_name == 'push' &&
+      !contains(github.event.head_commit.message, 'skip docker') &&
+      !contains(github.event.head_commit.message, 'skip ci')
+    needs:
+      - test_existing_repos
+      - test_kb-sdk_builds
+
+    steps:
+    - name: checkout git repo
+      uses: actions/checkout@v2
+
+    - name: set current branch name as TAG_NAME for docker image
+      shell: bash
+      run: echo "::set-env name=TAG_NAME::${GITHUB_REF#refs/heads/}"
+
+    - name: build and push to dockerhub
+      uses: opspresso/action-docker@master
+      with:
+        args: --docker
+      env:
+        USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        DOCKERFILE: "Dockerfile"
+        IMAGE_NAME: "kbase/kb-sdk"
+


### PR DESCRIPTION
for the data upload project ticket [DATAUP-88](https://kbase-jira.atlassian.net/browse/DATAUP-88)

This adds an automated build and push to Dockerhub (if the appropriate auth credentials are supplied in the repo settings) when merges are made into the `master` and `develop` branches. The dockerhub images will be tagged with `master` and `develop` respectively.

The DockerHub auth hasn't been added to this repo, but here's an image I uploaded to my own dockerhub workspace using the same workflow:

https://hub.docker.com/layers/ialarmedalien/kb-sdk/autobuild_docker_images/images/sha256-8ab997902b5e81c49f0ee9bade1f278cfbb2446191da2b658cd8a303d48305b6?context=repo