### PR TITLE
Makefile template change for develop branch.

### DIFF
--- a/src/java/us/kbase/templates/module_makefile.vm.properties
+++ b/src/java/us/kbase/templates/module_makefile.vm.properties
@@ -124,7 +124,7 @@ build-test-script:
 #if($language == "python")
 	echo 'export PYTHONPATH=$$script_dir/../$(LIB_DIR):$$PATH:$$PYTHONPATH' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'cd $$script_dir/../$(TEST_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'python -m nose --with-coverage --cover-package=$(SERVICE_CAPS) --cover-html --cover-html-dir=/kb/module/work/test_coverage --nocapture  --nologcapture .' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
+	echo 'python -m nose --with-coverage --cover-package=$(SERVICE_CAPS) --cover-html --cover-html-dir=/kb/module/work/test_coverage --cover-xml --cover-xml-file=/kb/module/work/test_coverage/coverage.xml --nocapture  --nologcapture .' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 #end
 #if($language == "java")
 	echo 'export JAVA_HOME=$(JAVA_HOME)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)


### PR DESCRIPTION
(Redoes change from #349)

As part of [DEVOPS-247](https://kbase-jira.atlassian.net/browse/DEVOPS-247), I've added XML output to the `Makefile` template for the Python `nose` tests.

This allows generation & upload of coverage reports as part of our CI build & test process.
This only addresses Python-based apps. Other changes may be needed for Java & Perl app testing.