### PR TITLE
Better perl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /test_scripts/test.cfg
 *.pyc
 env-*/
+submodules/auth

--- a/lib/Bio/KBase/DeploymentConfig.pm
+++ b/lib/Bio/KBase/DeploymentConfig.pm
@@ -1,6 +1,8 @@
 package Bio::KBase::DeploymentConfig;
 
 use strict;
+use warnings;
+
 use base 'Class::Accessor';
 use Config::Simple;
 
@@ -103,4 +105,3 @@ Return the name of the service currently configured.
 =cut
 
 1;
-

--- a/lib/Bio/KBase/DeploymentConfig.pm
+++ b/lib/Bio/KBase/DeploymentConfig.pm
@@ -4,7 +4,7 @@ use strict;
 use base 'Class::Accessor';
 use Config::Simple;
 
-__PACKAGE__->mk_accessors(qw(service_name settings));
+__PACKAGE__->mk_accessors( qw( service_name settings ) );
 
 =head1 NAME
 
@@ -13,9 +13,9 @@ Bio::KBase::DeploymentConfig
 =head1 DESCRIPTION
 
 The C<Bio::KBase::DeploymentConfig> class wraps the access to a KBase deployment.cfg
-file. It tests for the existence of the KB_DEPLOYMENT_CONFIG and 
-KB_SERVICE_NAME environment variables; if both are present, the 
-configuration parameters for the given service will be loaded 
+file. It tests for the existence of the KB_DEPLOYMENT_CONFIG and
+KB_SERVICE_NAME environment variables; if both are present, the
+configuration parameters for the given service will be loaded
 from that config file. If they are not present, the module supports
 fallback to defaults as defined by the module.
 
@@ -46,42 +46,36 @@ A hash reference containing the default values for the service parameters.
 =back
 
 =cut
-   
-sub new
-{
-    my($class, $service_name, $defaults) = @_;
 
-    if ((my $n = $ENV{KB_SERVICE_NAME}) ne "")
-    {
-	$service_name = $n;
+sub new {
+    my ( $class, $service_name, $defaults ) = @_;
+
+    if ( ( my $n = $ENV{ KB_SERVICE_NAME } ) ne "" ) {
+        $service_name = $n;
     }
 
     my $settings = {};
-    if (ref($defaults))
-    {
-	%$settings = %$defaults;
+    if ( ref( $defaults ) ) {
+        %$settings = %$defaults;
     }
 
-    my $cfg_file = $ENV{KB_DEPLOYMENT_CONFIG};
-    if (-e $cfg_file)
-    {
-	my $cfg = Config::Simple->new();
-	$cfg->read($cfg_file);
+    my $cfg_file = $ENV{ KB_DEPLOYMENT_CONFIG };
+    if ( -e $cfg_file ) {
+        my $cfg = Config::Simple->new();
+        $cfg->read( $cfg_file );
 
-	my %cfg = $cfg->vars;
+        my %config = $cfg->vars;
 
-	for my $k (keys %cfg)
-	{
-	    if ($k =~ /^$service_name\.(.*)/)
-	    {
-		$settings->{$1} = $cfg{$k};
-	    }
-	}
+        for my $k ( keys %config ) {
+            if ( $k =~ /^$service_name\.(.*)/ ) {
+                $settings->{ $1 } = $config{ $k };
+            }
+        }
     }
 
     my $self = {
-	settings => $settings,
-	service_name => $service_name,
+        settings     => $settings,
+        service_name => $service_name,
     };
 
     return bless $self, $class;
@@ -91,14 +85,13 @@ sub new
 
 Retrieve a setting from the configuration.
 
-   my $value = $obj->setting("key-name");
+   my $value = $obj->setting( "key-name" );
 
 =cut
 
-sub setting
-{
-    my($self, $key) = @_;
-    return $self->{settings}->{$key};
+sub setting {
+    my ( $self, $key ) = @_;
+    return $self->{ settings }->{ $key };
 }
 
 =item C<service_name>
@@ -110,3 +103,4 @@ Return the name of the service currently configured.
 =cut
 
 1;
+

--- a/lib/Bio/KBase/Exceptions.pm
+++ b/lib/Bio/KBase/Exceptions.pm
@@ -1,50 +1,52 @@
 package Bio::KBase::Exceptions;
 
-use Exception::Class
-    (
-     Bio::KBase::Exceptions::KBaseException => {
-	 description => 'KBase exception',
-	 fields => ['method_name'],
-     },
+use Exception::Class (
+    Bio::KBase::Exceptions::KBaseException => {
+        description => 'KBase exception',
+        fields      => [ 'method_name' ],
+    },
 
-     Bio::KBase::Exceptions::JSONRPC => {
-	 description => 'JSONRPC error',
-	 fields => ['code', 'data'],
-	 isa => 'Bio::KBase::Exceptions::KBaseException',
-     },
+    Bio::KBase::Exceptions::JSONRPC => {
+        description => 'JSONRPC error',
+        fields      => [ 'code', 'data' ],
+        isa         => 'Bio::KBase::Exceptions::KBaseException',
+    },
 
-     Bio::KBase::Exceptions::HTTP => {
-	 description => 'HTTP error',
-	 fields => ['status_line'],
-	 isa => 'Bio::KBase::Exceptions::KBaseException',
-     },
+    Bio::KBase::Exceptions::HTTP => {
+        description => 'HTTP error',
+        fields      => [ 'status_line' ],
+        isa         => 'Bio::KBase::Exceptions::KBaseException',
+    },
 
-     Bio::KBase::Exceptions::ArgumentValidationError => {
-	 description => 'argument validation error',
-	 fields => ['method_name'],
-	 isa => 'Bio::KBase::Exceptions::KBaseException',
-     },
+    Bio::KBase::Exceptions::ArgumentValidationError => {
+        description => 'argument validation error',
+        fields      => [ 'method_name' ],
+        isa         => 'Bio::KBase::Exceptions::KBaseException',
+    },
+);
 
-    );
-
-Bio::KBase::Exceptions::KBaseException->Trace(1);
+Bio::KBase::Exceptions::KBaseException->Trace( 1 );
 
 package Bio::KBase::Exceptions::HTTP;
 use strict;
 
-sub full_message
-{
-    my($self) = @_;
-    return $self->message . "\nHTTP status: " . $self->status_line . "\nFunction invoked: " . $self->method_name;
+sub full_message {
+    my ( $self ) = @_;
+    return
+          $self->message
+        . "\nHTTP status: "
+        . $self->status_line
+        . "\nFunction invoked: "
+        . $self->method_name;
 }
 
 package Bio::KBase::Exceptions::JSONRPC;
 use strict;
 
-sub full_message
-{
-    my($self) = @_;
-    return sprintf("JSONRPC error:\n%s\nJSONRPC error code: %s\nJSONRPC error data:%s\n", $self->message, $self->code, $self->data);
+sub full_message {
+    my ( $self ) = @_;
+    return sprintf( "JSONRPC error:\n%s\nJSONRPC error code: %s\nJSONRPC error data:%s\n",
+        $self->message, $self->code, $self->data );
 }
 
 1;

--- a/lib/Bio/KBase/Exceptions.pm
+++ b/lib/Bio/KBase/Exceptions.pm
@@ -1,5 +1,8 @@
 package Bio::KBase::Exceptions;
 
+use strict;
+use warnings;
+
 use Exception::Class (
     Bio::KBase::Exceptions::KBaseException => {
         description => 'KBase exception',
@@ -29,6 +32,7 @@ Bio::KBase::Exceptions::KBaseException->Trace( 1 );
 
 package Bio::KBase::Exceptions::HTTP;
 use strict;
+use warnings;
 
 sub full_message {
     my ( $self ) = @_;
@@ -42,6 +46,7 @@ sub full_message {
 
 package Bio::KBase::Exceptions::JSONRPC;
 use strict;
+use warnings;
 
 sub full_message {
     my ( $self ) = @_;

--- a/lib/Bio/KBase/Log.pm
+++ b/lib/Bio/KBase/Log.pm
@@ -431,7 +431,7 @@ sub _syslog {
 sub _log {
     my ( $self, $ident, $message ) = @_;
     my $time = POSIX::strftime( "%Y-%m-%d %H:%M:%S", localtime );
-    my $msg  = join( " ", $time, hostname(), $ident . ": " );
+    my $msg  = join " ", $time, hostname(), $ident . ": ";
     open LOG, ">>" . $self->get_log_file()
         || warn "Could not print log message $msg to " . $self->get_log_file() . "\n";
     if ( ref( $message ) eq 'ARRAY' ) {

--- a/lib/Bio/KBase/Log.pm
+++ b/lib/Bio/KBase/Log.pm
@@ -14,51 +14,52 @@ use Time::HiRes;
 use Sys::Syslog qw( :DEFAULT setlogsock);
 
 # $ENV{'MLOG_CONFIG_FILE'} should point to an INI-formatted file, or an empty string, or should not exist.
-our $MLOG_ENV_FILE = "MLOG_CONFIG_FILE";
-my $_GLOBAL = "global";
-our $MLOG_LOG_LEVEL = "mlog_log_level";
-our $MLOG_API_URL = "mlog_api_url";
-our $MLOG_LOG_FILE = "mlog_log_file";
+our $MLOG_ENV_FILE      = "MLOG_CONFIG_FILE";
+my $_GLOBAL             = "global";
+our $MLOG_LOG_LEVEL     = "mlog_log_level";
+our $MLOG_API_URL       = "mlog_api_url";
+our $MLOG_LOG_FILE      = "mlog_log_file";
 
-our $DEFAULT_LOG_LEVEL = 6;
-our $MSG_FACILITY = 'local1';
-our $EMERG_FACILITY = 'local0';
+our $DEFAULT_LOG_LEVEL  = 6;
+our $MSG_FACILITY       = 'local1';
+our $EMERG_FACILITY     = 'local0';
 
-our $EMERG = 0;
-our $ALERT = 1;
-our $CRIT = 2;
-our $ERR = 3;
+our $EMERG   = 0;
+our $ALERT   = 1;
+our $CRIT    = 2;
+our $ERR     = 3;
 our $WARNING = 4;
-our $NOTICE = 5;
-our $INFO = 6;
-our $DEBUG = 7;
-our $DEBUG2 = 8;
-our $DEBUG3 = 9;
+our $NOTICE  = 5;
+our $INFO    = 6;
+our $DEBUG   = 7;
+our $DEBUG2  = 8;
+our $DEBUG3  = 9;
 
-my $_MLOG_TEXT_TO_LEVEL = { 'EMERG' => $EMERG,
-                            'ALERT' => $ALERT,
-                            'CRIT' => $CRIT,
-                            'ERR' => $ERR,
-                            'WARNING' => $WARNING,
-                            'NOTICE' => $NOTICE,
-                            'INFO' => $INFO,
-                            'DEBUG' => $DEBUG,
-                            'DEBUG2' => $DEBUG2,
-                            'DEBUG3' => $DEBUG3,
-                            };
+my $_MLOG_TEXT_TO_LEVEL = {
+    'EMERG'   => $EMERG,
+    'ALERT'   => $ALERT,
+    'CRIT'    => $CRIT,
+    'ERR'     => $ERR,
+    'WARNING' => $WARNING,
+    'NOTICE'  => $NOTICE,
+    'INFO'    => $INFO,
+    'DEBUG'   => $DEBUG,
+    'DEBUG2'  => $DEBUG2,
+    'DEBUG3'  => $DEBUG3,
+};
 
-my @_MLOG_TO_SYSLOG = (0, 1, 2, 3, 4, 5, 6, 7, 7, 7);
+my @_MLOG_TO_SYSLOG = ( 0, 1, 2, 3, 4, 5, 6, 7, 7, 7 );
 
 my $_MLOG_LEVEL_TO_TEXT = {};
-foreach my $k (keys %{$_MLOG_TEXT_TO_LEVEL}) {
-        $_MLOG_LEVEL_TO_TEXT->{$_MLOG_TEXT_TO_LEVEL->{$k}} = $k;
+foreach my $k ( keys %{ $_MLOG_TEXT_TO_LEVEL } ) {
+    $_MLOG_LEVEL_TO_TEXT->{ $_MLOG_TEXT_TO_LEVEL->{ $k } } = $k;
 }
 
-our $LOG_LEVEL_MIN = min(keys %{$_MLOG_LEVEL_TO_TEXT});
-our $LOG_LEVEL_MAX = max(keys %{$_MLOG_LEVEL_TO_TEXT});
+our $LOG_LEVEL_MIN = min( keys %{ $_MLOG_LEVEL_TO_TEXT } );
+our $LOG_LEVEL_MAX = max( keys %{ $_MLOG_LEVEL_TO_TEXT } );
 
-our $USER = $ENV{'USER'};
-our $PARENT_FILE = abs_path($0);
+our $USER        = $ENV{ 'USER' };
+our $PARENT_FILE = abs_path( $0 );
 
 =pod
 
@@ -174,275 +175,303 @@ clear_user_log_level() : Removes the user-defined log level.
 =cut
 
 sub _get_option {
-    my ($opts, $key) = @_;
-    if(!(defined $opts)) {
+    my ( $opts, $key ) = @_;
+    if ( !( defined $opts ) ) {
         return undef;
     }
-    return defined $opts->{$key} ? $opts->{$key} : undef;
+    return defined $opts->{ $key } ? $opts->{ $key } : undef;
 }
 
 sub new {
-    my ($class, $sub, $lc, $options) = @_;
-    unless(defined $sub) {
+    my ( $class, $sub, $lc, $options ) = @_;
+    unless ( defined $sub ) {
         die "ERROR: You must define a subsystem when calling init_log()\n";
     }
     my $self = {};
     bless $self, $class;
-    $self->{authuser} = _get_option($options, 'authuser');
-    $self->{module} = _get_option($options, 'module');
-    $self->{method} = _get_option($options, 'method');
-    $self->{call_id} = _get_option($options, 'call_id');
-    $self->{ip_address} = _get_option($options, 'ip_address');
-    $self->{tag} = _get_option($options, 'tag');
-    $self->{_callback} = defined $options->{"changecallback"} ? 
-            $options->{"changecallback"} : sub {};
-    $self->{_subsystem} = $sub;
-    $self->{_mlog_config_file} = _get_option($options, 'config');
-    if(!(defined $self->{_mlog_config_file})) {
-        $self->{_mlog_config_file} = defined $ENV{$MLOG_ENV_FILE} ?
-                $ENV{$MLOG_ENV_FILE} : undef;
+    $self->{ authuser }   = _get_option( $options, 'authuser' );
+    $self->{ module }     = _get_option( $options, 'module' );
+    $self->{ method }     = _get_option( $options, 'method' );
+    $self->{ call_id }    = _get_option( $options, 'call_id' );
+    $self->{ ip_address } = _get_option( $options, 'ip_address' );
+    $self->{ tag }        = _get_option( $options, 'tag' );
+    $self->{ _callback }
+        = defined $options->{ "changecallback" }
+        ? $options->{ "changecallback" }
+        : sub { };
+    $self->{ _subsystem }        = $sub;
+    $self->{ _mlog_config_file } = _get_option( $options, 'config' );
+
+    if ( !( defined $self->{ _mlog_config_file } ) ) {
+        $self->{ _mlog_config_file }
+            = defined $ENV{ $MLOG_ENV_FILE } ? $ENV{ $MLOG_ENV_FILE } : undef;
     }
-    $self->{_user_log_level} = -1;
-    $self->{_config_log_level} = -1;
-    $self->{_user_log_file} = _get_option($options, 'logfile');
-    $self->{_config_log_file} = undef;
-    $self->{_api_log_level} = -1;
-    $self->{_msgs_since_config_update} = 0;
-    $self->{_time_at_config_update} = "";
-    $self->{msg_count} = 0;
-    $self->{_recheck_api_msg} = 100;
-    $self->{_recheck_api_time} = 300;  # 5 mins
-    if(defined $lc) {
-        $self->{_log_constraints} = $lc;
+    $self->{ _user_log_level }           = -1;
+    $self->{ _config_log_level }         = -1;
+    $self->{ _user_log_file }            = _get_option( $options, 'logfile' );
+    $self->{ _config_log_file }          = undef;
+    $self->{ _api_log_level }            = -1;
+    $self->{ _msgs_since_config_update } = 0;
+    $self->{ _time_at_config_update }    = "";
+    $self->{ msg_count }                 = 0;
+    $self->{ _recheck_api_msg }          = 100;
+    $self->{ _recheck_api_time }         = 300;                                  # 5 mins
+
+    if ( defined $lc ) {
+        $self->{ _log_constraints } = $lc;
     }
 
-    $self->{_init} = 1;
+    $self->{ _init } = 1;
     $self->update_config();
-    $self->{_init} = undef;
+    $self->{ _init } = undef;
     return $self;
 }
 
 sub _get_time_since_start {
-    my ($self) = @_;
-    my $now = time;
-    my $seconds_duration = $now - $self->{_time_at_config_update};
+    my ( $self )         = @_;
+    my $now              = time;
+    my $seconds_duration = $now - $self->{ _time_at_config_update };
     return $seconds_duration;
 }
 
 sub get_log_level {
-    my ($self) = @_;
-    if($self->{_user_log_level} != -1) {
-        return $self->{_user_log_level};
-    } elsif($self->{_config_log_level} != -1) {
-        return $self->{_config_log_level};
-    } elsif($self->{_api_log_level} != -1) {
-        return $self->{_api_log_level};
-    } else {
+    my ( $self ) = @_;
+    if ( $self->{ _user_log_level } != -1 ) {
+        return $self->{ _user_log_level };
+    }
+    elsif ( $self->{ _config_log_level } != -1 ) {
+        return $self->{ _config_log_level };
+    }
+    elsif ( $self->{ _api_log_level } != -1 ) {
+        return $self->{ _api_log_level };
+    }
+    else {
         return $DEFAULT_LOG_LEVEL;
     }
 }
 
 sub update_config {
-    my ($self) = @_;
+    my ( $self ) = @_;
     my $loglevel = $self->get_log_level();
-    my $logfile = $self->get_log_file();
-    
-    $self->{_api_log_level} = -1;
-    $self->{_msgs_since_config_update} = 0;
-    $self->{_time_at_config_update} = time;
-    
+    my $logfile  = $self->get_log_file();
+
+    $self->{ _api_log_level }            = -1;
+    $self->{ _msgs_since_config_update } = 0;
+    $self->{ _time_at_config_update }    = time;
+
     # Retrieving config variables.
     my $api_url = "";
-    if(defined $self->{_mlog_config_file} && -e $self->{_mlog_config_file} &&
-             -s $self->{_mlog_config_file} > 0) {
-        my $cfg = new Config::Simple($self->{_mlog_config_file});
-        my $cfgitems = $cfg->get_block($_GLOBAL);
-        my $subitems = $cfg->get_block($self->{_subsystem});
-        foreach my $k (keys %{$subitems}) {
-            $cfgitems->{$k} = $subitems->{$k};
+    if ( defined $self->{ _mlog_config_file }
+        && -e $self->{ _mlog_config_file }
+        && -s $self->{ _mlog_config_file } > 0 ) {
+        my $cfg      = new Config::Simple( $self->{ _mlog_config_file } );
+        my $cfgitems = $cfg->get_block( $_GLOBAL );
+        my $subitems = $cfg->get_block( $self->{ _subsystem } );
+        foreach my $k ( keys %{ $subitems } ) {
+            $cfgitems->{ $k } = $subitems->{ $k };
         }
-        if(defined $cfgitems->{$MLOG_LOG_LEVEL}) {
-            if($cfgitems->{$MLOG_LOG_LEVEL} !~ /^\d+$/) {
-                warn "Cannot parse log level " . $cfgitems->{$MLOG_LOG_LEVEL} . 
-                    " from file " . $self->{_mlog_config_file} . 
-                    " to int. Keeping current log level.";
-            } else {
-                $self->{_config_log_level} = $cfgitems->{$MLOG_LOG_LEVEL};
+        if ( defined $cfgitems->{ $MLOG_LOG_LEVEL } ) {
+            if ( $cfgitems->{ $MLOG_LOG_LEVEL } !~ /^\d+$/ ) {
+                warn "Cannot parse log level "
+                    . $cfgitems->{ $MLOG_LOG_LEVEL }
+                    . " from file "
+                    . $self->{ _mlog_config_file }
+                    . " to int. Keeping current log level.";
+            }
+            else {
+                $self->{ _config_log_level } = $cfgitems->{ $MLOG_LOG_LEVEL };
             }
         }
-        if(defined $cfgitems->{$MLOG_API_URL}) {
-            $api_url = $cfgitems->{$MLOG_API_URL};
+        if ( defined $cfgitems->{ $MLOG_API_URL } ) {
+            $api_url = $cfgitems->{ $MLOG_API_URL };
         }
-        if(defined $cfgitems->{$MLOG_LOG_FILE}) {
-            $self->{_config_log_file} = $cfgitems->{$MLOG_LOG_FILE}
+        if ( defined $cfgitems->{ $MLOG_LOG_FILE } ) {
+            $self->{ _config_log_file } = $cfgitems->{ $MLOG_LOG_FILE };
         }
-    } elsif (defined $self->{_mlog_config_file}) {
-        warn "Cannot read config file " . $self->{_mlog_config_file};
+    }
+    elsif ( defined $self->{ _mlog_config_file } ) {
+        warn "Cannot read config file " . $self->{ _mlog_config_file };
     }
 
-    unless($api_url eq "") {
-        my $subsystem_api_url = $api_url."/".$self->{_subsystem};
-        my $json = get($subsystem_api_url);
-        if(defined $json) {
-            my $decoded_json = decode_json($json);
+    unless ( $api_url eq "" ) {
+        my $subsystem_api_url = $api_url . "/" . $self->{ _subsystem };
+        my $json              = get( $subsystem_api_url );
+        if ( defined $json ) {
+            my $decoded_json       = decode_json( $json );
             my $max_matching_level = -1;
-            foreach my $constraint_set (@{$decoded_json->{'log_levels'}}) {
-                my $level = $constraint_set->{'level'};
-                my $constraints = $constraint_set->{'constraints'};
-                if($level <= $max_matching_level) {
+            foreach my $constraint_set ( @{ $decoded_json->{ 'log_levels' } } ) {
+                my $level       = $constraint_set->{ 'level' };
+                my $constraints = $constraint_set->{ 'constraints' };
+                if ( $level <= $max_matching_level ) {
                     next;
                 }
                 my $matches = 1;
-                foreach my $constraint (keys %{$constraints}) {
-                    if(! exists $self->{_log_constraints}->{$constraint}) {
+                foreach my $constraint ( keys %{ $constraints } ) {
+                    if ( !exists $self->{ _log_constraints }->{ $constraint } ) {
                         $matches = 0;
-                    } elsif($self->{_log_constraints}->{$constraint} ne $constraints->{$constraint}) {
+                    }
+                    elsif ( $self->{ _log_constraints }->{ $constraint } ne
+                        $constraints->{ $constraint } )
+                    {
                         $matches = 0;
                     }
                 }
-                if($matches == 1) {
+                if ( $matches == 1 ) {
                     $max_matching_level = $level;
                 }
             }
-            $self->{_api_log_level} = $max_matching_level;
-        } else {
-            warn "Could not retrieve Log subsystem from control API at: $subsystem_api_url";
+            $self->{ _api_log_level } = $max_matching_level;
+        }
+        else {
+            warn
+                "Could not retrieve Log subsystem from control API at: $subsystem_api_url";
         }
     }
 }
 
 sub _resolve_log_level {
-    my ($self, $level) = @_;
-    if(defined $_MLOG_TEXT_TO_LEVEL->{$level}) {
-        $level = $_MLOG_TEXT_TO_LEVEL->{$level};
-    } elsif (!(defined $_MLOG_LEVEL_TO_TEXT->{$level})) {
+    my ( $self, $level ) = @_;
+    if ( defined $_MLOG_TEXT_TO_LEVEL->{ $level } ) {
+        $level = $_MLOG_TEXT_TO_LEVEL->{ $level };
+    }
+    elsif ( !( defined $_MLOG_LEVEL_TO_TEXT->{ $level } ) ) {
         die "Illegal log level";
     }
     return $level;
 }
 
 sub set_log_level {
-    my ($self, $level) = @_;
-    $self->{_user_log_level} = $self->_resolve_log_level($level);
-    $self->{_callback}();
+    my ( $self, $level ) = @_;
+    $self->{ _user_log_level } = $self->_resolve_log_level( $level );
+    $self->{ _callback }();
 }
 
 sub get_log_file {
-    my ($self) = @_;
-    if ($self->{_user_log_file}) {
-        return $self->{_user_log_file};
+    my ( $self ) = @_;
+    if ( $self->{ _user_log_file } ) {
+        return $self->{ _user_log_file };
     }
-    if ($self->{_config_log_file}) {
-        return $self->{_config_log_file};
+    if ( $self->{ _config_log_file } ) {
+        return $self->{ _config_log_file };
     }
     return undef;
 }
 
 sub set_log_file {
-    my ($self, $filename) = @_;
-    $self->{_user_log_file} = $filename;
-    $self->{_callback}();
+    my ( $self, $filename ) = @_;
+    $self->{ _user_log_file } = $filename;
+    $self->{ _callback }();
 }
 
 sub set_log_msg_check_count {
-    my ($self, $count) = @_;
-    if($count !~ /^\d+$/ || $count < 0) {
-        die "Format for calling set_log_msg_check_count is set_log_msg_check_count(integer count)\n";
+    my ( $self, $count ) = @_;
+    if ( $count !~ /^\d+$/ || $count < 0 ) {
+        die
+            "Format for calling set_log_msg_check_count is set_log_msg_check_count(integer count)\n";
     }
-    $self->{_recheck_api_msg} = $count;
+    $self->{ _recheck_api_msg } = $count;
 }
 
 sub set_log_msg_check_interval {
-    my ($self, $interval) = @_;
-    if($interval !~ /^\d+$/ || $interval < 0) {
-        die "Format for calling set_log_msg_check_interval is set_log_msg_check_interval(integer seconds)\n";
+    my ( $self, $interval ) = @_;
+    if ( $interval !~ /^\d+$/ || $interval < 0 ) {
+        die
+            "Format for calling set_log_msg_check_interval is set_log_msg_check_interval(integer seconds)\n";
     }
-    $self->{_recheck_api_time} = $interval;
+    $self->{ _recheck_api_time } = $interval;
 }
 
 sub clear_user_log_level {
-    my ($self) = @_;
-    $self->{_user_log_level} = -1;
+    my ( $self ) = @_;
+    $self->{ _user_log_level } = -1;
 }
 
 sub _get_ident {
-    my ($self, $level, $authuser, $module, $method, $call_id, $ip_address, $tag) = @_;
-    my @infos = ($self->{_subsystem}, $_MLOG_LEVEL_TO_TEXT->{$level},
-                    Time::HiRes::time(), $USER, $PARENT_FILE, $$);
-    if ($self->{ip_address}) {
+    my ( $self, $level, $authuser, $module, $method, $call_id, $ip_address, $tag ) = @_;
+    my @infos = (
+        $self->{ _subsystem },
+        $_MLOG_LEVEL_TO_TEXT->{ $level },
+        Time::HiRes::time(), $USER, $PARENT_FILE, $$
+    );
+    if ( $self->{ ip_address } ) {
         push @infos, $ip_address || '-';
     }
-    if ($self->{authuser}) {
+    if ( $self->{ authuser } ) {
         push @infos, $authuser || '-';
     }
-    if ($self->{module}) {
+    if ( $self->{ module } ) {
         push @infos, $module || '-';
     }
-    if ($self->{method}) {
+    if ( $self->{ method } ) {
         push @infos, $method || '-';
     }
-    if ($self->{call_id}) {
+    if ( $self->{ call_id } ) {
         push @infos, $call_id || '-';
     }
-    if ($self->{tag}) {
+    if ( $self->{ tag } ) {
         push @infos, $tag || '-';
     }
-    return "[" . join("] [", @infos). "]";
+    return "[" . join( "] [", @infos ) . "]";
 }
 
 sub _syslog {
-    my ($self, $facility, $level, $ident, $message) = @_;
-    openlog($ident, "", $facility);
-    if(ref($message) eq 'ARRAY') {
-        foreach my $m (@{$message}) {
-            syslog($_MLOG_TO_SYSLOG[$level], "$m");
+    my ( $self, $facility, $level, $ident, $message ) = @_;
+    openlog( $ident, "", $facility );
+    if ( ref( $message ) eq 'ARRAY' ) {
+        foreach my $m ( @{ $message } ) {
+            syslog( $_MLOG_TO_SYSLOG[ $level ], "$m" );
         }
-    } else {
-        syslog($_MLOG_TO_SYSLOG[$level], "$message");
+    }
+    else {
+        syslog( $_MLOG_TO_SYSLOG[ $level ], "$message" );
     }
     closelog();
 }
 
 sub _log {
-    my ($self, $ident, $message) = @_;
-    my $time = POSIX::strftime("%Y-%m-%d %H:%M:%S", localtime);
-    my $msg = join(" ", $time, hostname(), $ident . ": ");
-    open LOG, ">>" . $self->get_log_file() ||
-        warn "Could not print log message $msg to " . $self->get_log_file() . "\n";
-    if(ref($message) eq 'ARRAY') {
-        foreach my $m (@{$message}) {
+    my ( $self, $ident, $message ) = @_;
+    my $time = POSIX::strftime( "%Y-%m-%d %H:%M:%S", localtime );
+    my $msg  = join( " ", $time, hostname(), $ident . ": " );
+    open LOG, ">>" . $self->get_log_file()
+        || warn "Could not print log message $msg to " . $self->get_log_file() . "\n";
+    if ( ref( $message ) eq 'ARRAY' ) {
+        foreach my $m ( @{ $message } ) {
             print LOG $msg . "$m\n";
         }
-    } else {
+    }
+    else {
         print LOG $msg . "$message\n";
     }
     close LOG;
 }
 
 sub log_message {
-    my ($self, $level, $message, $authuser, $module, $method, $call_id,
-        $ip_address, $tag) = @_;
-    $level = $self->_resolve_log_level($level);
+    my (
+        $self,   $level,   $message,    $authuser, $module,
+        $method, $call_id, $ip_address, $tag
+    ) = @_;
+    $level = $self->_resolve_log_level( $level );
 
-    ++$self->{msg_count};
-    ++$self->{_msgs_since_config_update};
+    ++$self->{ msg_count };
+    ++$self->{ _msgs_since_config_update };
 
-    if($self->{_msgs_since_config_update} >= $self->{_recheck_api_msg} ||
-        $self->_get_time_since_start() >= $self->{_recheck_api_time}) {
+    if ( $self->{ _msgs_since_config_update } >= $self->{ _recheck_api_msg }
+        || $self->_get_time_since_start() >= $self->{ _recheck_api_time } ) {
         $self->update_config();
     }
 
-    my $ident = $self->_get_ident($level, $authuser, $module, $method, $call_id,
-        $ip_address, $tag);
+    my $ident = $self->_get_ident( $level, $authuser, $module, $method, $call_id,
+        $ip_address, $tag );
+
     # If this message is an emergency, send a copy to the emergency facility first.
-    if($level == 0) {
-        $self->_syslog($EMERG_FACILITY, $level, $ident, $message);
+    if ( $level == 0 ) {
+        $self->_syslog( $EMERG_FACILITY, $level, $ident, $message );
     }
 
-    if($level <= $self->get_log_level()) {
-        $self->_syslog($MSG_FACILITY, $level, $ident, $message);
-        if($self->get_log_file()) {
-            $self->_log($ident, $message);
+    if ( $level <= $self->get_log_level() ) {
+        $self->_syslog( $MSG_FACILITY, $level, $ident, $message );
+        if ( $self->get_log_file() ) {
+            $self->_log( $ident, $message );
         }
     }
 }

--- a/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
+++ b/src/java/us/kbase/mobu/initializer/ModuleInitializer.java
@@ -25,7 +25,7 @@ public class ModuleInitializer {
     private boolean verbose;
     private File dir;
 
-    private static String[] subdirs = {"data",
+    private static String[] subdirs = { "data",
                                         "scripts",
                                         "lib",
                                         "test",

--- a/src/java/us/kbase/scripts/test/Test8.perl.properties
+++ b/src/java/us/kbase/scripts/test/Test8.perl.properties
@@ -1,5 +1,8 @@
 package StoringImpl;
+
 use strict;
+use warnings;
+
 use Bio::KBase::Exceptions;
 # Use Semantic Versioning (2.0.0-rc.1)
 # http://semver.org

--- a/src/java/us/kbase/templates/module_dockerfile.vm.properties
+++ b/src/java/us/kbase/templates/module_dockerfile.vm.properties
@@ -3,7 +3,7 @@ FROM kbase/sdkbase2:python
 #else
 FROM kbase/sdkbase2:latest
 #end
-
+LABEL maintainer="#if($user_name)${user_name}#{else}KBase Developer#{end}"
 # -----------------------------------------
 # In this section, you can install any system dependencies required
 # to run your App.  For instance, you could place an apt-get update or

--- a/src/java/us/kbase/templates/module_dockerfile.vm.properties
+++ b/src/java/us/kbase/templates/module_dockerfile.vm.properties
@@ -3,7 +3,6 @@ FROM kbase/sdkbase2:python
 #else
 FROM kbase/sdkbase2:latest
 #end
-MAINTAINER #if($username)${username}#{else}KBase Developer#{end}
 
 # -----------------------------------------
 # In this section, you can install any system dependencies required
@@ -34,15 +33,13 @@ RUN R -q -e 'if(!require(raster)) install.packages("raster", repos="http://cran.
 RUN apt-get -y install r-cran-evaluate r-cran-codetools r-cran-testthat
 #end
 
-# -----------------------------------------
-
 COPY ./ /kb/module
-RUN mkdir -p /kb/module/work
-RUN chmod -R a+rw /kb/module
 
 WORKDIR /kb/module
 
-RUN make all
+RUN mkdir -p /kb/module/work && \
+    chmod -R a+rw /kb/module && \
+    make all
 
 ENTRYPOINT [ "./scripts/entrypoint.sh" ]
 

--- a/src/java/us/kbase/templates/module_makefile.vm.properties
+++ b/src/java/us/kbase/templates/module_makefile.vm.properties
@@ -63,7 +63,7 @@ build-executable-script:
 #if($language == "perl")
 	echo '#!/bin/bash' > $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
 	echo 'script_dir=$$(dirname "$$(readlink -f "$$0")")' >> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
-	echo 'export PERL5LIB=$$script_dir/../$(LIB_DIR):$$PATH:$$PERL5LIB' >> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
+	echo 'export PERL5LIB=$$script_dir/../$(LIB_DIR):$$PERL5LIB' >> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
 	echo 'perl $$script_dir/../$(LIB_DIR)/$(SERVICE_CAPS)/$(SERVICE_CAPS)Server.pm $$1 $$2 $$3' >> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
 #end
 #if($language == "python")
@@ -89,7 +89,7 @@ build-startup-script:
 	echo 'script_dir=$$(dirname "$$(readlink -f "$$0")")' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
 #if($language == "perl")
 	echo 'export KB_DEPLOYMENT_CONFIG=$$script_dir/../deploy.cfg' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
-	echo 'export PERL5LIB=$$script_dir/../$(LIB_DIR):$$PATH:$$PERL5LIB' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
+	echo 'export PERL5LIB=$$script_dir/../$(LIB_DIR):$$PERL5LIB' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
 	echo 'plackup $$script_dir/../$(LIB_DIR)/$(SERVICE_CAPS).psgi' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
 #end
 #if($language == "python")
@@ -117,7 +117,7 @@ build-test-script:
 	echo 'rm -rf $(WORK_DIR)/*' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'echo "...done removing temp files."' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 #if($language == "perl")
-	echo 'export PERL5LIB=$$script_dir/../$(LIB_DIR):$$PATH:$$PERL5LIB' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
+	echo 'export PERL5LIB=$$script_dir/../$(LIB_DIR):$$PERL5LIB' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'cd $$script_dir/../$(TEST_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo "perl -e 'opendir my ${esc.print("\")}${esc.print("$")}${esc.print("$")}dh, \".\"; my @l = grep { /\\\\.pl${esc.print("\")}${esc.print("$")}${esc.print("$")}/ } readdir ${esc.print("\")}${esc.print("$")}${esc.print("$")}dh; my ${esc.print("\")}${esc.print("$")}${esc.print("$")}ret=0; foreach my ${esc.print("\")}${esc.print("$")}${esc.print("$")}s (@l) { print(\"Running \".${esc.print("\")}${esc.print("$")}${esc.print("$")}s.\"\\\\n\"); system(\"perl\", ${esc.print("\")}${esc.print("$")}${esc.print("$")}s) && do{${esc.print("\")}${esc.print("$")}${esc.print("$")}ret=2; next;}; } exit(${esc.print("\")}${esc.print("$")}${esc.print("$")}ret);'" >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 #end

--- a/src/java/us/kbase/templates/module_perl_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_perl_impl.vm.properties
@@ -1,6 +1,8 @@
-#if ($example)
 package ${module_name}::${module_name}Impl;
+
 use strict;
+use warnings;
+
 use Bio::KBase::Exceptions;
 # Use Semantic Versioning (2.0.0-rc.1)
 # http://semver.org
@@ -20,22 +22,26 @@ This sample module contains one small method that filters contigs.
 =cut
 
 #BEGIN_HEADER
+use feature qw( say );
 use Bio::KBase::AuthToken;
-use installed_clients::AssemblyUtilClient;
 use installed_clients::KBaseReportClient;
 use Config::IniFiles;
+#if ($example)
+use installed_clients::AssemblyUtilClient;
 use Bio::SeqIO;
 use Data::Dumper;
+#end
 #END_HEADER
 
 sub new {
     my ( $class, @args ) = @_;
     my $self = {};
     bless $self, $class;
+
     #BEGIN_CONSTRUCTOR
 
     my $config_file         = $ENV{ KB_DEPLOYMENT_CONFIG };
-    my $cfg                 = Config::IniFiles->new(-file=>$config_file);
+    my $cfg                 = Config::IniFiles->new( -file => $config_file );
     my $scratch             = $cfg->val('${module_name}', 'scratch');
     my $callbackURL         = $ENV{ SDK_CALLBACK_URL };
 
@@ -44,15 +50,13 @@ sub new {
 
     #END_CONSTRUCTOR
 
-    if ($self->can('_init_instance'))
-    {
+    if ( $self->can( '_init_instance' ) ) {
         $self->_init_instance();
     }
     return $self;
 }
 
 =head1 METHODS
-
 
 
 =head2 run_${module_name}
@@ -74,11 +78,13 @@ sub run_${module_name} {
     my $self = shift;
     my ( $params ) = @_;
 
-    my @_bad_arguments;
-    ( ref($params) eq 'HASH' ) or push( @_bad_arguments, "Invalid type for argument \"params\" (value was \"$params\")" );
-    if (@_bad_arguments) {
+    my @bad_arguments;
+    ( ref( $params ) eq 'HASH' ) or push @_bad_arguments,
+        "Invalid type for argument \"params\" "
+        . "(value was \"$params\")";
+    if ( @bad_arguments ) {
         my $msg = "Invalid arguments passed to run_${module_name}:\n"
-            . join( "", map { "\t$_\n" } @_bad_arguments );
+            . join "", map { "\t$_\n" } @bad_arguments;
         Bio::KBase::Exceptions::ArgumentValidationError->throw(
             error       => $msg,
             method_name => 'run_${module_name}'
@@ -86,12 +92,11 @@ sub run_${module_name} {
     }
 
     my $ctx = $${module_name}::${module_name}Server::CallContext;
-    my $output;
+    my ( $output );
     #BEGIN run_${module_name}
-
+#if ($example)
     # Print statements to stdout/stderr are captured and available as the App log
-    print("Starting run_${module_name} method. Parameters:\n");
-    print(Dumper($params) . "\n");
+    say "Starting run_${module_name} method. Parameters: " . Dumper $params;
 
     # Step 1 - Parse/examine the parameters and catch any errors
     # It is important to check that parameters exist and are defined, and that nice error
@@ -121,7 +126,7 @@ sub run_${module_name} {
     # We can use the AssemblyUtils module to download a FASTA file from our Assembly data
     # object. The return object gives us the path to the file that was created.
 
-    print("Downloading assembly data as FASTA file.\n");
+    say "Downloading assembly data as FASTA file.";
     my $assycli = installed_clients::AssemblyUtilClient->new( $self->{ callbackURL } );
     my $fileobj = $assycli->get_assembly_as_fasta( { ref => $assy_ref } );
 
@@ -141,7 +146,7 @@ sub run_${module_name} {
         }
     }
     my $result_text = "Filtered assembly to " . $remaining . " contigs out of " . $total;
-    print($result_text . "\n");
+    say $result_text;
 
     # Step 4 - Save the new Assembly back to the system
     my $newref = $assycli->save_assembly_from_fasta( {
@@ -168,7 +173,7 @@ sub run_${module_name} {
 
     # Step 6 - construct the output to send back
 
-    my $output = {
+    $output = {
         assembly_output     => $newref,
         n_initial_contigs   => $total,
         n_contigs_remaining => $remaining,
@@ -177,20 +182,36 @@ sub run_${module_name} {
         report_ref          => $report->{ ref }
     };
 
-    print("returning: ".Dumper($output)."\n");
+    say "returning: " . Dumper $output;
+#else
+    my $repcli = installed_clients::KBaseReportClient->new( $self->{ callbackURL } );
+    my $report = $repcli->create( {
+        workspace_name => $params->{ workspace_name },
+        report => {
+            text_message    => $params->{ parameter_1 },
+            objects_created => []
+        }
+    } );
 
+    my $output = {
+        report_name => $report->{ name },
+        report_ref  => $report->{ ref }
+    };
+#end
     #END run_${module_name}
-    my @_bad_returns;
-    ( ref($output) eq 'HASH' ) or push( @_bad_returns, "Invalid type for return variable \"output\" (value was \"$output\")" );
-    if ( @_bad_returns ) {
+    my @bad_returns;
+    ( ref($output) eq 'HASH' ) or push @bad_returns,
+        "Invalid type for return variable \"output\" "
+        . "(value was \"$output\")";
+    if ( @bad_returns ) {
         my $msg = "Invalid returns passed to run_${module_name}:\n"
-            . join( "", map { "\t$_\n" } @_bad_returns );
+            . join "", map { "\t$_\n" } @bad_returns;
         Bio::KBase::Exceptions::ArgumentValidationError->throw(
             error       => $msg,
             method_name => 'run_${module_name}'
         );
     }
-    return( $output );
+    return ( $output );
 }
 
 
@@ -199,7 +220,7 @@ sub run_${module_name} {
 
   $return = $obj->status()
 
-=over 4
+=over
 
 =item Parameter and return types
 
@@ -240,44 +261,3 @@ sub status {
 }
 
 1;
-#else
-#BEGIN_HEADER
-use Bio::KBase::AuthToken;
-use installed_clients::KBaseReportClient;
-use Config::IniFiles;
-#END_HEADER
-#BEGIN_CONSTRUCTOR
-    my $config_file = $ENV{ KB_DEPLOYMENT_CONFIG };
-    my $cfg         = Config::IniFiles->new( -file => $config_file );
-    my $scratch     = $cfg->val( '${module_name}', 'scratch' );
-    my $callbackURL = $ENV{ SDK_CALLBACK_URL };
-
-    $self->{ scratch }      = $scratch;
-    $self->{ callbackURL }  = $callbackURL;
-#END_CONSTRUCTOR
-#BEGIN run_${module_name}
-    my $repcli = installed_clients::KBaseReportClient->new( $self->{ callbackURL } );
-    my $report = $repcli->create({
-        workspace_name => $params->{ workspace_name },
-        report => {
-            text_message    => $params->{parameter_1},
-            objects_created => []
-        }
-    });
-
-    my $output = {
-        report_name => $report->{ name },
-        report_ref  => $report->{ ref }
-    };
-#END run_${module_name}
-
-#BEGIN_STATUS
-    $return = {
-        "state"           => "OK",
-        "message"         => "",
-        "version"         => $VERSION,
-        "git_url"         => $GIT_URL,
-        "git_commit_hash" => $GIT_COMMIT_HASH
-    };
-#END_STATUS
-#end

--- a/src/java/us/kbase/templates/module_perl_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_perl_impl.vm.properties
@@ -3,7 +3,7 @@ package ${module_name}::${module_name}Impl;
 use strict;
 use Bio::KBase::Exceptions;
 # Use Semantic Versioning (2.0.0-rc.1)
-# http://semver.org 
+# http://semver.org
 our $VERSION = '0.0.1';
 our $GIT_URL = '';
 our $GIT_COMMIT_HASH = '';
@@ -28,22 +28,20 @@ use Bio::SeqIO;
 use Data::Dumper;
 #END_HEADER
 
-sub new
-{
-    my($class, @args) = @_;
-    my $self = {
-    };
+sub new {
+    my ( $class, @args ) = @_;
+    my $self = {};
     bless $self, $class;
     #BEGIN_CONSTRUCTOR
-    
-    my $config_file = $ENV{ KB_DEPLOYMENT_CONFIG };
-    my $cfg = Config::IniFiles->new(-file=>$config_file);
-    my $scratch = $cfg->val('${module_name}', 'scratch');
-    my $callbackURL = $ENV{ SDK_CALLBACK_URL };
-    
-    $self->{scratch} = $scratch;
-    $self->{callbackURL} = $callbackURL;
-    
+
+    my $config_file         = $ENV{ KB_DEPLOYMENT_CONFIG };
+    my $cfg                 = Config::IniFiles->new(-file=>$config_file);
+    my $scratch             = $cfg->val('${module_name}', 'scratch');
+    my $callbackURL         = $ENV{ SDK_CALLBACK_URL };
+
+    $self->{scratch}        = $scratch;
+    $self->{callbackURL}    = $callbackURL;
+
     #END_CONSTRUCTOR
 
     if ($self->can('_init_instance'))
@@ -65,126 +63,139 @@ sub new
 
 The actual function is declared using 'funcdef' to specify the name
 and input/return arguments to the function.  For all typical KBase
-Apps that run in the Narrative, your function should have the 
+Apps that run in the Narrative, your function should have the
 'authentication required' modifier.
 
 =back
 
 =cut
 
-sub run_${module_name}
-{
+sub run_${module_name} {
     my $self = shift;
-    my($params) = @_;
+    my ( $params ) = @_;
 
     my @_bad_arguments;
-    (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument \"params\" (value was \"$params\")");
+    ( ref($params) eq 'HASH' ) or push( @_bad_arguments, "Invalid type for argument \"params\" (value was \"$params\")" );
     if (@_bad_arguments) {
-    my $msg = "Invalid arguments passed to run_${module_name}:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-                                   method_name => 'run_${module_name}');
+        my $msg = "Invalid arguments passed to run_${module_name}:\n"
+            . join( "", map { "\t$_\n" } @_bad_arguments );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'run_${module_name}'
+        );
     }
 
     my $ctx = $${module_name}::${module_name}Server::CallContext;
-    my($output);
+    my $output;
     #BEGIN run_${module_name}
-    
+
     # Print statements to stdout/stderr are captured and available as the App log
     print("Starting run_${module_name} method. Parameters:\n");
     print(Dumper($params) . "\n");
-    
+
     # Step 1 - Parse/examine the parameters and catch any errors
     # It is important to check that parameters exist and are defined, and that nice error
     # messages are returned to users.  Parameter values go through basic validation when
     # defined in a Narrative App, but advanced users or other SDK developers can call
     # this function directly, so validation is still important.
-    
-    if (!exists $params->{'workspace_name'}) {
+
+    if ( !exists $params->{ 'workspace_name' } ) {
         die "Parameter workspace_name is not set in input arguments";
     }
-    my $workspace_name=$params->{'workspace_name'};
-    
-    if (!exists $params->{'assembly_input_ref'}) {
+    my $workspace_name = $params->{ 'workspace_name' };
+
+    if ( !exists $params->{ 'assembly_input_ref' } ) {
         die "Parameter assembly_input_ref is not set in input arguments";
     }
-    my $assy_ref=$params->{'assembly_input_ref'};
-    
-    if (!exists $params->{'min_length'}) {
+    my $assy_ref = $params->{ 'assembly_input_ref' };
+
+    if ( !exists $params->{ 'min_length' } ) {
         die "Parameter min_length is not set in input arguments";
     }
-    my $min_length = $params->{'min_length'};
-    if ($min_length < 0) {
-        die "min_length parameter cannot be negative (".$min_length.")";
+    my $min_length = $params->{ 'min_length' };
+    if ( $min_length < 0 ) {
+        die "min_length parameter cannot be negative (" . $min_length . ")";
     }
-    
+
     # Step 2 - Download the input data as a Fasta file
     # We can use the AssemblyUtils module to download a FASTA file from our Assembly data
     # object. The return object gives us the path to the file that was created.
-    
+
     print("Downloading assembly data as FASTA file.\n");
-    my $assycli = installed_clients::AssemblyUtilClient->new($self->{callbackURL});
-    my $fileobj = $assycli->get_assembly_as_fasta({ref => $assy_ref});
-    
+    my $assycli = installed_clients::AssemblyUtilClient->new( $self->{ callbackURL } );
+    my $fileobj = $assycli->get_assembly_as_fasta( { ref => $assy_ref } );
+
     # Step 3 - Actually perform the filter operation, saving the good contigs to a new
     # fasta file.
-    
-    my $sio_in = Bio::SeqIO->new(-file => $fileobj->{path});
-    my $outfile = $self->{scratch} . "/" . "filtered.fasta";
-    my $sio_out = Bio::SeqIO->new(-file => ">$outfile", -format=> "fasta");
+
+    my $sio_in  = Bio::SeqIO->new( -file => $fileobj->{ path } );
+    my $outfile = $self->{ scratch } . "/" . "filtered.fasta";
+    my $sio_out = Bio::SeqIO->new( -file => ">$outfile", -format => "fasta" );
     my $total = 0;
     my $remaining = 0;
-    while (my $seq = $sio_in->next_seq) {
+    while ( my $seq = $sio_in->next_seq ) {
         $total++;
-        if ($seq->length >= $min_length) {
+        if ( $seq->length >= $min_length ) {
             $remaining++;
-            $sio_out->write_seq($seq);
+            $sio_out->write_seq( $seq );
         }
     }
     my $result_text = "Filtered assembly to " . $remaining . " contigs out of " . $total;
     print($result_text . "\n");
-    
+
     # Step 4 - Save the new Assembly back to the system
-    my $newref = $assycli->save_assembly_from_fasta({assembly_name => $fileobj->{assembly_name},
-                                                     workspace_name => $workspace_name,
-                                                     file => {path => $outfile}});
+    my $newref = $assycli->save_assembly_from_fasta( {
+        assembly_name => $fileobj->{ assembly_name },
+        workspace_name => $workspace_name,
+        file           => {
+            path => $outfile
+        }
+    } );
+
 
     # Step 5 - Build a report and return
-    my $repcli = installed_clients::KBaseReportClient->new($self->{callbackURL});
-    my $report = $repcli->create(
-        {workspace_name => $workspace_name,
-         report => {text_message => $result_text,
-                    objects_created => [{description => "Filtered contigs",
-                                         ref => $newref}
-                                        ]
-                    }
-         });
-    
+    my $repcli = installed_clients::KBaseReportClient->new( $self->{ callbackURL } );
+    my $report = $repcli->create( {
+        workspace_name  => $workspace_name,
+        report          => {
+            text_message    => $result_text,
+            objects_created => [ {
+                description => "Filtered contigs",
+                ref         => $newref
+            } ]
+        }
+    } );
+
     # Step 6 - construct the output to send back
-    
-    my $output = {assembly_output => $newref,
-                  n_initial_contigs => $total,
-                  n_contigs_remaining => $remaining,
-                  n_contigs_removed => $total - $remaining,
-                  report_name => $report->{name},
-                  report_ref => $report->{ref}};
+
+    my $output = {
+        assembly_output     => $newref,
+        n_initial_contigs   => $total,
+        n_contigs_remaining => $remaining,
+        n_contigs_removed   => $total - $remaining,
+        report_name         => $report->{ name },
+        report_ref          => $report->{ ref }
+    };
 
     print("returning: ".Dumper($output)."\n");
-    
+
     #END run_${module_name}
     my @_bad_returns;
-    (ref($output) eq 'HASH') or push(@_bad_returns, "Invalid type for return variable \"output\" (value was \"$output\")");
-    if (@_bad_returns) {
-    my $msg = "Invalid returns passed to run_${module_name}:\n" . join("", map { "\t$_\n" } @_bad_returns);
-    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-                                   method_name => 'run_${module_name}');
+    ( ref($output) eq 'HASH' ) or push( @_bad_returns, "Invalid type for return variable \"output\" (value was \"$output\")" );
+    if ( @_bad_returns ) {
+        my $msg = "Invalid returns passed to run_${module_name}:\n"
+            . join( "", map { "\t$_\n" } @_bad_returns );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'run_${module_name}'
+        );
     }
-    return($output);
+    return( $output );
 }
 
 
 
-
-=head2 status 
+=head2 status
 
   $return = $obj->status()
 
@@ -215,12 +226,17 @@ Return the module status. This is a structure including Semantic Versioning numb
 =cut
 
 sub status {
-    my($return);
+    my $return;
     #BEGIN_STATUS
-    $return = {"state" => "OK", "message" => "", "version" => $VERSION,
-               "git_url" => $GIT_URL, "git_commit_hash" => $GIT_COMMIT_HASH};
+    $return = {
+        "state"           => "OK",
+        "message"         => "",
+        "version"         => $VERSION,
+        "git_url"         => $GIT_URL,
+        "git_commit_hash" => $GIT_COMMIT_HASH
+    };
     #END_STATUS
-    return($return);
+    return ( $return );
 }
 
 1;
@@ -232,30 +248,36 @@ use Config::IniFiles;
 #END_HEADER
 #BEGIN_CONSTRUCTOR
     my $config_file = $ENV{ KB_DEPLOYMENT_CONFIG };
-    my $cfg = Config::IniFiles->new(-file=>$config_file);
-    my $scratch = $cfg->val('${module_name}', 'scratch');
+    my $cfg         = Config::IniFiles->new( -file => $config_file );
+    my $scratch     = $cfg->val( '${module_name}', 'scratch' );
     my $callbackURL = $ENV{ SDK_CALLBACK_URL };
 
-    $self->{scratch} = $scratch;
-    $self->{callbackURL} = $callbackURL;
+    $self->{ scratch }      = $scratch;
+    $self->{ callbackURL }  = $callbackURL;
 #END_CONSTRUCTOR
 #BEGIN run_${module_name}
-    my $repcli = installed_clients::KBaseReportClient->new($self->{callbackURL});
+    my $repcli = installed_clients::KBaseReportClient->new( $self->{ callbackURL } );
     my $report = $repcli->create({
-        workspace_name => $params->{workspace_name},
+        workspace_name => $params->{ workspace_name },
         report => {
-            text_message => $params->{parameter_1},
+            text_message    => $params->{parameter_1},
             objects_created => []
         }
     });
 
     my $output = {
-        report_name => $report->{name},
-        report_ref => $report->{ref}
+        report_name => $report->{ name },
+        report_ref  => $report->{ ref }
     };
 #END run_${module_name}
 
 #BEGIN_STATUS
-    $return = {"state" => "OK", "message" => "", "version" => $VERSION, "git_url" => $GIT_URL, "git_commit_hash" => $GIT_COMMIT_HASH};
+    $return = {
+        "state"           => "OK",
+        "message"         => "",
+        "version"         => $VERSION,
+        "git_url"         => $GIT_URL,
+        "git_commit_hash" => $GIT_COMMIT_HASH
+    };
 #END_STATUS
 #end

--- a/src/java/us/kbase/templates/module_test_perl_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_perl_client.vm.properties
@@ -11,24 +11,33 @@ use installed_clients::AssemblyUtilClient;
 use ${module_name}::${module_name}Impl;
 
 local $| = 1;
-my $token = $ENV{'KB_AUTH_TOKEN'};
-my $config_file = $ENV{'KB_DEPLOYMENT_CONFIG'};
-my $config = new Config::Simple($config_file)->get_block('${module_name}');
-my $ws_url = $config->{"workspace-url"};
-my $ws_name = undef;
+my $token        = $ENV{ 'KB_AUTH_TOKEN' };
+my $config_file  = $ENV{ 'KB_DEPLOYMENT_CONFIG' };
+my $callback_url = $ENV{ 'SDK_CALLBACK_URL' };
+
+my $config    = new Config::Simple( $config_file )->get_block( '${module_name}' );
+my $ws_url    = $config->{ "workspace-url" };
+my $ws_name   = undef;
 my $ws_client = new installed_clients::WorkspaceClient($ws_url,token => $token);
-my $scratch = $config->{scratch};
-my $callback_url = $ENV{'SDK_CALLBACK_URL'};
-my $auth_token = Bio::KBase::AuthToken->new(token => $token, ignore_authrc => 1, auth_svc=>$config->{'auth-service-url'});
-my $ctx = LocalCallContext->new($token, $auth_token->user_id);
+
+my $scratch   = $config->{ scratch };
+
+my $auth_token   = Bio::KBase::AuthToken->new(
+    token         => $token,
+    ignore_authrc => 1,
+    auth_svc      => $config->{ 'auth-service-url' }
+);
+
+my $ctx = LocalCallContext->new( $token, $auth_token->user_id );
 $${module_name}::${module_name}Server::CallContext = $ctx;
+
 my $impl = new ${module_name}::${module_name}Impl();
 
 sub get_ws_name {
-    if (!defined($ws_name)) {
-        my $suffix = int(time * 1000);
-        $ws_name = 'test_${module_name}_' . $suffix;
-        $ws_client->create_workspace({workspace => $ws_name});
+    if ( !defined( $ws_name ) ) {
+        my $suffix  = int( time * 1000 );
+        $ws_name    = 'test_${module_name}_' . $suffix;
+        $ws_client->create_workspace( { workspace => $ws_name } );
     }
     return $ws_name;
 }
@@ -38,13 +47,16 @@ sub load_fasta {
     my $filename = shift;
     my $object_name = shift;
     my $filecontents = shift;
-    open (my $fh, '>', $filename) or die "Could not open file '$filename' ${dollar_sign}!";
+    open ( my $fh, '>', $filename )
+        or die "Could not open file '$filename' ${dollar_sign}!";
     print $fh $filecontents;
     close $fh;
-    my $assycli = installed_clients::AssemblyUtilClient->new($callback_url);
-    return $assycli->save_assembly_from_fasta({assembly_name => $object_name,
-                                               workspace_name => get_ws_name(),
-                                               file => {path => $filename}});
+    my $assycli = installed_clients::AssemblyUtilClient->new( $callback_url );
+    return $assycli->save_assembly_from_fasta( {
+            assembly_name  => $object_name,
+            workspace_name => get_ws_name(),
+            file           => { path => $filename }
+    } );
 }
 #end
 
@@ -58,13 +70,15 @@ eval {
                        "agctt\n" .
                        ">seq3\n" .
                        "agcttttcatgg";
-         
-    my $ref = load_fasta($scratch . "/test1.fasta", "TestAssembly", $fastaContent);
+
+    my $ref = load_fasta( $scratch . "/test1.fasta", "TestAssembly", $fastaContent );
 
     # Second, call the implementation
-    my $ret = $impl->run_${module_name}({workspace_name => get_ws_name(),
-                                     assembly_input_ref => $ref,
-                                     min_length => 10});
+    my $ret = $impl->run_${module_name}( {
+        workspace_name      => get_ws_name(),
+        assembly_input_ref  => $ref,
+        min_length          => 10,
+    } );
 
     # validate the returned data
     ok($ret->{n_initial_contigs} eq 3, "number of initial contigs");
@@ -72,31 +86,31 @@ eval {
     ok($ret->{n_contigs_remaining} eq 2, "number of remaining contigs");
 
     $@ = '';
-    eval { 
+    eval {
         $impl->run_${module_name}({workspace_name => get_ws_name(),
                                assembly_input_ref=>"fake",
                                min_length => 10});
     };
     like($@, qr#separators / in object reference fake#);
-    
-    eval { 
+
+    eval {
         $impl->run_${module_name}({workspace_name => get_ws_name(),
                                assembly_input_ref => "fake",
                                min_length => -10});
     };
     like($@, qr/min_length parameter cannot be negative/);
-    
+
     eval {
         $impl->run_${module_name}({workspace_name => get_ws_name(),
                                assembly_input_ref => "fake"});
     };
     like($@, qr/Parameter min_length is not set in input arguments/);
-    
+
     done_testing(6);
 #else
     # Prepare test data using the appropriate uploader for that data (see the KBase function
     # catalog for help, https://narrative.kbase.us/#catalog/functions)
-    
+
     # Run your method by
     # my $ret = $impl->your_method(parameters...);
     #
@@ -128,37 +142,49 @@ if (defined($err)) {
 }
 
 {
+
     package LocalCallContext;
     use strict;
     sub new {
-        my($class,$token,$user) = @_;
+        my ( $class, $token, $user ) = @_;
         my $self = {
-            token => $token,
+            token   => $token,
             user_id => $user
         };
         return bless $self, $class;
     }
+
     sub user_id {
-        my($self) = @_;
-        return $self->{user_id};
+        my ( $self ) = @_;
+        return $self->{ user_id };
     }
+
     sub token {
-        my($self) = @_;
-        return $self->{token};
+        my ( $self ) = @_;
+        return $self->{ token };
     }
+
     sub provenance {
-        my($self) = @_;
-        return [{'service' => '${module_name}', 'method' => 'please_never_use_it_in_production', 'method_params' => []}];
+        my ( $self ) = @_;
+        return [ {
+                'service'       => '${module_name}',
+                'method'        => 'please_never_use_it_in_production',
+                'method_params' => [],
+            }
+        ];
     }
+
     sub authenticated {
         return 1;
     }
+
     sub log_debug {
-        my($self,$msg) = @_;
-        print STDERR $msg."\n";
+        my ( $self, $msg ) = @_;
+        print STDERR $msg . "\n";
     }
+
     sub log_info {
-        my($self,$msg) = @_;
-        print STDERR $msg."\n";
+        my ( $self, $msg ) = @_;
+        print STDERR $msg . "\n";
     }
 }

--- a/src/java/us/kbase/templates/module_test_perl_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_perl_client.vm.properties
@@ -1,4 +1,6 @@
 use strict;
+use warnings;
+
 use Data::Dumper;
 use Test::More;
 use Config::Simple;
@@ -15,10 +17,10 @@ my $token        = $ENV{ 'KB_AUTH_TOKEN' };
 my $config_file  = $ENV{ 'KB_DEPLOYMENT_CONFIG' };
 my $callback_url = $ENV{ 'SDK_CALLBACK_URL' };
 
-my $config    = new Config::Simple( $config_file )->get_block( '${module_name}' );
+my $config       = Config::Simple->new( $config_file )->get_block( '${module_name}' );
 my $ws_url    = $config->{ "workspace-url" };
 my $ws_name   = undef;
-my $ws_client = new installed_clients::WorkspaceClient($ws_url,token => $token);
+my $ws_client = installed_clients::WorkspaceClient->new($ws_url,token => $token);
 
 my $scratch   = $config->{ scratch };
 
@@ -31,7 +33,7 @@ my $auth_token   = Bio::KBase::AuthToken->new(
 my $ctx = LocalCallContext->new( $token, $auth_token->user_id );
 $${module_name}::${module_name}Server::CallContext = $ctx;
 
-my $impl = new ${module_name}::${module_name}Impl();
+my $impl = ${module_name}::${module_name}Impl->new();
 
 sub get_ws_name {
     if ( !defined( $ws_name ) ) {
@@ -145,6 +147,8 @@ if (defined($err)) {
 
     package LocalCallContext;
     use strict;
+    use warnings;
+
     sub new {
         my ( $class, $token, $user ) = @_;
         my $self = {
@@ -187,4 +191,7 @@ if (defined($err)) {
         my ( $self, $msg ) = @_;
         print STDERR $msg . "\n";
     }
+
+    1;
+
 }

--- a/src/java/us/kbase/templates/perl_client.vm.properties
+++ b/src/java/us/kbase/templates/perl_client.vm.properties
@@ -1,8 +1,10 @@
 package ${client_package_name};
 
+use strict;
+use warnings;
+
 use JSON::RPC::Client;
 use POSIX;
-use strict;
 use Data::Dumper;
 use URI;
 use Bio::KBase::Exceptions;
@@ -124,7 +126,7 @@ sub new {
             }
         }
 
-        if (exists $self->{ token } ) {
+        if ( exists $self->{ token } ) {
             $self->{ client }{ token } = $self->{ token };
         }
     }
@@ -134,31 +136,37 @@ sub new {
     my $timeout = $ENV${empty_escaper}{ CDMI_TIMEOUT } || ( 30 * 60 );
     $ua->timeout( $timeout );
     bless $self, $class;
-    #    $self->_validate_version();
     return $self;
 }
 
 #foreach( $module in $modules )
 #if( $any_async || $async_version)
+# Authentication: ${method.authentication}
 sub _check_job {
     my ( $self, @args ) = @_;
-# Authentication: ${method.authentication}
-    if ((my $n = @args) != 1) {
-        Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
-                                   "Invalid argument count for function _check_job (received $n, expecting 1)");
+
+    if ( ( my $n = @args ) != 1 ) {
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error =>  "Invalid argument count for function _check_job "
+                      . "(received $n, expecting 1)"
+        );
     }
-    {
-        my($job_id) = @args;
-        my @_bad_arguments;
-        (!ref($job_id)) or push(@_bad_arguments, "Invalid type for argument 0 \"job_id\" (it should be a string)");
-        if (@_bad_arguments) {
-            my $msg = "Invalid arguments passed to _check_job:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-            Bio::KBase::Exceptions::ArgumentValidationError->throw(
-                error       => $msg,
-                method_name => '_check_job'
-            );
-        }
+
+    my ( $job_id ) = @args;
+
+    my @bad_arguments;
+    ( ! ref( $job_id ) ) or push @bad_arguments,
+    "Invalid type for argument 0 \"job_id\" (it should be a string)";
+
+    if ( @bad_arguments ) {
+        my $msg = "Invalid arguments passed to _check_job:\n"
+            . join "", map { "\t$_\n" } @bad_arguments;
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => '_check_job'
+        );
     }
+
     my $result = $self->{ client }->call(
         $self->{ url },
         $self->{ headers },
@@ -241,7 +249,7 @@ sub ${method.name} {
     my $job_id          = $self->_${method.name}_submit( @args );
     my $async_job_check_time = $self->{ async_job_check_time };
     while (1) {
-        Time::HiRes::sleep($async_job_check_time);
+        Time::HiRes::sleep( $async_job_check_time );
         $async_job_check_time *= $self->{ async_job_check_time_scale_percent } / 100.0;
         if ( $async_job_check_time > $self->{ async_job_check_max_time } ) {
             $async_job_check_time = $self->{ async_job_check_max_time };
@@ -258,24 +266,31 @@ sub ${method.name} {
     }
 }
 
+# Authentication: ${method.authentication}
 sub _${method.name}_submit {
     my ( $self, @args ) = @_;
-# Authentication: ${method.authentication}
-    if ((my $n = @args) != ${method.arg_count}) {
-        Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
-                                   "Invalid argument count for function _${method.name}_submit (received $n, expecting ${method.arg_count})");
+    if ( ( my $n = @args ) != ${method.arg_count} ) {
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error =>  "Invalid argument count for function _${method.name}_submit "
+                      . "(received $n, expecting ${method.arg_count})"
+        );
     }
 #if( $method.arg_count > 0 )
     {
-        my(${method.arg_vars}) = @args;
-        my @_bad_arguments;
+        my ( ${method.arg_vars} ) = @args;
+        my @bad_arguments;
 #foreach( $param in $method.params )
-        (${param.validator}) or push(@_bad_arguments, "Invalid type for argument ${param.index} \"${param.name}\" (value was \"${param.perl_var}\")");
+        ( ${param.validator} ) or push @bad_arguments,
+            "Invalid type for argument ${param.index} \"${param.name}\" "
+            .  "(value was \"${param.perl_var}\")";
 #end
-        if (@_bad_arguments) {
-            my $msg = "Invalid arguments passed to _${method.name}_submit:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-            Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-                                   method_name => '_${method.name}_submit');
+        if ( @bad_arguments ) {
+            my $msg = "Invalid arguments passed to _${method.name}_submit:\n"
+                . join "", map { "\t$_\n" } @bad_arguments;
+            Bio::KBase::Exceptions::ArgumentValidationError->throw(
+                error       => $msg,
+                method_name => '_${method.name}_submit'
+            );
         }
     }
 #end
@@ -303,7 +318,7 @@ sub _${method.name}_submit {
                 data        => $result->content->{ error }{ error },
             );
         } else {
-            return $result->result->[0];  # job_id
+            return $result->result->[ 0 ];  # job_id
         }
     } else {
         Bio::KBase::Exceptions::HTTP->throw(
@@ -315,26 +330,29 @@ sub _${method.name}_submit {
 }
 
 #else ## of if-any-async
+# Authentication: ${method.authentication}
 sub ${method.name} {
     my ( $self, @args ) = @_;
 
-# Authentication: ${method.authentication}
-
     if ( ( my $n = @args ) != ${method.arg_count} ) {
         Bio::KBase::Exceptions::ArgumentValidationError->throw(
-            error => "Invalid argument count for function ${method.name} (received $n, expecting ${method.arg_count})"
+            error =>  "Invalid argument count for function ${method.name} "
+                      . "(received $n, expecting ${method.arg_count})"
         );
     }
 #if( $method.arg_count > 0 )
     {
-        my( ${method.arg_vars} ) = @args;
+        my ( ${method.arg_vars} ) = @args;
 
-        my @_bad_arguments;
+        my @bad_arguments;
 #foreach( $param in $method.params )
-        ( ${param.validator} ) or push( @_bad_arguments, "Invalid type for argument ${param.index} \"${param.name}\" (value was \"${param.perl_var}\")" );
+        ( ${param.validator} ) or push @bad_arguments,
+            "Invalid type for argument ${param.index} \"${param.name}\" "
+            . "(value was \"${param.perl_var}\")";
 #end
-        if ( @_bad_arguments ) {
-            my $msg = "Invalid arguments passed to ${method.name}:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+        if ( @bad_arguments ) {
+            my $msg = "Invalid arguments passed to ${method.name}:\n"
+                . join "", map { "\t$_\n" } @bad_arguments;
             Bio::KBase::Exceptions::ArgumentValidationError->throw(
                 error       => $msg,
                 method_name => '${method.name}'
@@ -414,7 +432,8 @@ sub status {
     my $job_id = undef;
     if ( ( my $n = @args ) != 0 ) {
         Bio::KBase::Exceptions::ArgumentValidationError->throw(
-            error => "Invalid argument count for function status (received $n, expecting 0)");
+            error =>  "Invalid argument count for function status "
+                      . "(received $n, expecting 0)");
     }
     my $context = undef;
     if ( $self->{ service_version } ) {
@@ -440,7 +459,7 @@ sub status {
                 data        => $result->content->{ error }{ error },
             );
         } else {
-            $job_id = $result->result->[0];
+            $job_id = $result->result->[ 0 ];
         }
     } else {
         Bio::KBase::Exceptions::HTTP->throw(
@@ -449,31 +468,37 @@ sub status {
             method_name => '_status_submit',
         );
     }
-    my $async_job_check_time = $self->{async_job_check_time};
-    while (1) {
-        Time::HiRes::sleep($async_job_check_time);
-        $async_job_check_time *= $self->{async_job_check_time_scale_percent} / 100.0;
-        if ($async_job_check_time > $self->{async_job_check_max_time}) {
-            $async_job_check_time = $self->{async_job_check_max_time};
+    my $async_job_check_time = $self->{ async_job_check_time };
+    while ( 1 ) {
+        Time::HiRes::sleep( $async_job_check_time );
+        $async_job_check_time *= $self->{ async_job_check_time_scale_percent } / 100.0;
+        if ( $async_job_check_time > $self->{ async_job_check_max_time } ) {
+            $async_job_check_time = $self->{ async_job_check_max_time };
         }
-        my $job_state_ref = $self->_check_job($job_id);
-        if ($job_state_ref->{"finished"} != 0) {
-            if (!exists $job_state_ref->{"result"}) {
-                $job_state_ref->{"result"} = [];
+        my $job_state_ref = $self->_check_job( $job_id );
+        if ( $job_state_ref->{ "finished" } != 0 ) {
+            if ( !exists $job_state_ref->{ "result" } ) {
+                $job_state_ref->{ "result" } = [];
             }
-            return wantarray ? @{$job_state_ref->{"result"}} : $job_state_ref->{"result"}->[0];
+            return wantarray
+                ? @{ $job_state_ref->{ "result" } }
+                : $job_state_ref->{ "result" }->[ 0 ];
         }
     }
+
 }
 #else ## of if-status-async
 
 sub status {
     my ( $self, @args ) = @_;
 
-    if ((my $n = @args) != 0) {
+    if ( ( my $n = @args ) != 0 ) {
         Bio::KBase::Exceptions::ArgumentValidationError->throw(
-            error => "Invalid argument count for function status (received $n, expecting 0)");
+            error =>  "Invalid argument count for function status "
+                      . "(received $n, expecting 0)"
+        );
     }
+
 #if( $dynserv_ver )
 
     my $service_state = $self->{ client }->call(
@@ -537,7 +562,7 @@ sub status {
 
 sub version {
     my ( $self ) = @_;
-    my $result = $self->{client}->call(
+    my $result = $self->{ client }->call(
         $self->{ url },
         $self->{ headers },
         {
@@ -652,8 +677,8 @@ sub call {
 
 #if( $enable_client_retry )
 
-    my @retries = (1, 2, 5, 10, 20, 60, 60, 60, 60, 60, 60);
-    my %codes_to_retry =  map { $_ => 1 } qw(110 408 502 503 504 200) ;
+    my @retries = ( 1, 2, 5, 10, 20, 60, 60, 60, 60, 60, 60 );
+    my %codes_to_retry =  map { $_ => 1 } qw( 110 408 502 503 504 200 ) ;
     my $n_retries;
 
     while (1)

--- a/src/java/us/kbase/templates/perl_client.vm.properties
+++ b/src/java/us/kbase/templates/perl_client.vm.properties
@@ -38,74 +38,72 @@ ${module.module_doc}
 
 =cut
 
-sub new
-{
-    my($class, $url, @args) = @_;
-    
+sub new {
+    my ( $class, $url, @args ) = @_;
+
 #if( $default_service_url )
-    if (!defined($url))
-    {
-	$url = '${default_service_url}';
+    if ( !defined( $url ) ) {
+        $url = '${default_service_url}';
     }
 #end
 
     my $self = {
-	client => ${client_package_name}::RpcClient->new,
-	url => $url,
-	headers => [],
+        client  => ${client_package_name}::RpcClient->new,
+        url     => $url,
+        headers => [],
     };
+
 #if( $any_async || $async_version )
     my %arg_hash = @args;
-    $self->{async_job_check_time} = 0.1;
-    if (exists $arg_hash{"async_job_check_time_ms"}) {
-        $self->{async_job_check_time} = $arg_hash{"async_job_check_time_ms"} / 1000.0;
+    $self->{ async_job_check_time } = 0.1;
+    if ( exists $arg_hash{ async_job_check_time_ms } ) {
+        $self->{ async_job_check_time } = $arg_hash{ async_job_check_time_ms } / 1000.0;
     }
-    $self->{async_job_check_time_scale_percent} = 150;
-    if (exists $arg_hash{"async_job_check_time_scale_percent"}) {
-        $self->{async_job_check_time_scale_percent} = $arg_hash{"async_job_check_time_scale_percent"};
+
+    $self->{ async_job_check_time_scale_percent } = 150;
+    if ( exists $arg_hash{ async_job_check_time_scale_percent } ) {
+        $self->{ async_job_check_time_scale_percent } = $arg_hash{ async_job_check_time_scale_percent };
     }
-    $self->{async_job_check_max_time} = 300;  # 5 minutes
-    if (exists $arg_hash{"async_job_check_max_time_ms"}) {
-        $self->{async_job_check_max_time} = $arg_hash{"async_job_check_max_time_ms"} / 1000.0;
+
+    $self->{ async_job_check_max_time } = 300;    # 5 minutes
+    if ( exists $arg_hash{ async_job_check_max_time_ms } ) {
+        $self->{ async_job_check_max_time } = $arg_hash{ async_job_check_max_time_ms } / 1000.0;
     }
+
     my $service_version = #if($service_ver)'$service_ver'#{else}undef#{end};
-    if (exists $arg_hash{"service_version"}) {
-        $service_version = $arg_hash{"service_version"};
+    if ( exists $arg_hash{ "service_version" } ) {
+        $service_version = $arg_hash{ "service_version" };
     }
     $self->{service_version} = $service_version;
 #end
 
-    chomp($self->{hostname} = `hostname`);
-    $self->{hostname} ||= 'unknown-host';
+    chomp( $self->{ hostname } = `hostname` );
+    $self->{ hostname } ||= 'unknown-host';
 
     #
     # Set up for propagating KBRPC_TAG and KBRPC_METADATA environment variables through
     # to invoked services. If these values are not set, we create a new tag
     # and a metadata field with basic information about the invoking script.
     #
-    if ($ENV${empty_escaper}{KBRPC_TAG})
-    {
-	$self->{kbrpc_tag} = $ENV${empty_escaper}{KBRPC_TAG};
+    if ( $ENV${empty_escaper}{ KBRPC_TAG } ) {
+        $self->{ kbrpc_tag } = $ENV${empty_escaper}{ KBRPC_TAG };
     }
-    else
-    {
-	my ($t, $us) = &$get_time();
-	$us = sprintf("%06d", $us);
-	my $ts = strftime("%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t);
-	$self->{kbrpc_tag} = "C:$0:$self->{hostname}:$$:$ts";
+    else {
+        my ( $t, $us )       = &$get_time();
+        $us                  = sprintf( "%06d", $us );
+        my $ts               = strftime( "%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t );
+        $self->{ kbrpc_tag } = "C:$0:$self->{hostname}:$$:$ts";
     }
-    push(@{$self->{headers}}, 'Kbrpc-Tag', $self->{kbrpc_tag});
+    push @{ $self->{ headers } }, 'Kbrpc-Tag', $self->{ kbrpc_tag };
 
-    if ($ENV${empty_escaper}{KBRPC_METADATA})
-    {
-	$self->{kbrpc_metadata} = $ENV${empty_escaper}{KBRPC_METADATA};
-	push(@{$self->{headers}}, 'Kbrpc-Metadata', $self->{kbrpc_metadata});
+    if ( $ENV${empty_escaper}{ KBRPC_METADATA } ) {
+        $self->{ kbrpc_metadata } = $ENV${empty_escaper}{ KBRPC_METADATA };
+        push @{ $self->{ headers } }, 'Kbrpc-Metadata', $self->{ kbrpc_metadata };
     }
 
-    if ($ENV${empty_escaper}{KBRPC_ERROR_DEST})
-    {
-	$self->{kbrpc_error_dest} = $ENV${empty_escaper}{KBRPC_ERROR_DEST};
-	push(@{$self->{headers}}, 'Kbrpc-Errordest', $self->{kbrpc_error_dest});
+    if ( $ENV${empty_escaper}{ KBRPC_ERROR_DEST } ) {
+        $self->{ kbrpc_error_dest } = $ENV${empty_escaper}{ KBRPC_ERROR_DEST };
+        push @{ $self->{ headers } }, 'Kbrpc-Errordest', $self->{ kbrpc_error_dest };
     }
 
 #if( $authenticated )
@@ -115,26 +113,26 @@ sub new
     # We create an auth token, passing through the arguments that we were (hopefully) given.
 
     {
-	my %arg_hash2 = @args;
-	if (exists $arg_hash2{"token"}) {
-	    $self->{token} = $arg_hash2{"token"};
-	} elsif (exists $arg_hash2{"user_id"}) {
-	    my $token = Bio::KBase::AuthToken->new(@args);
-	    if (!$token->error_message) {
-	        $self->{token} = $token->token;
-	    }
-	}
-	
-	if (exists $self->{token})
-	{
-	    $self->{client}->{token} = $self->{token};
-	}
+        my %arg_hash2 = @args;
+        if ( exists $arg_hash2{ token } ) {
+            $self->{ token } = $arg_hash2{ token };
+        }
+        elsif ( exists $arg_hash2{ user_id } ) {
+            my $token = Bio::KBase::AuthToken->new( @args );
+            if ( !$token->error_message ) {
+                $self->{ token } = $token->token;
+            }
+        }
+
+        if (exists $self->{ token } ) {
+            $self->{ client }{ token } = $self->{ token };
+        }
     }
 #end
 
-    my $ua = $self->{client}->ua;	 
-    my $timeout = $ENV${empty_escaper}{CDMI_TIMEOUT} || (30 * 60);	 
-    $ua->timeout($timeout);
+    my $ua      = $self->{ client }->ua;
+    my $timeout = $ENV${empty_escaper}{ CDMI_TIMEOUT } || ( 30 * 60 );
+    $ua->timeout( $timeout );
     bless $self, $class;
     #    $self->_validate_version();
     return $self;
@@ -143,7 +141,7 @@ sub new
 #foreach( $module in $modules )
 #if( $any_async || $async_version)
 sub _check_job {
-    my($self, @args) = @_;
+    my ( $self, @args ) = @_;
 # Authentication: ${method.authentication}
     if ((my $n = @args) != 1) {
         Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
@@ -155,27 +153,38 @@ sub _check_job {
         (!ref($job_id)) or push(@_bad_arguments, "Invalid type for argument 0 \"job_id\" (it should be a string)");
         if (@_bad_arguments) {
             my $msg = "Invalid arguments passed to _check_job:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-            Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-                                   method_name => '_check_job');
+            Bio::KBase::Exceptions::ArgumentValidationError->throw(
+                error       => $msg,
+                method_name => '_check_job'
+            );
         }
     }
-    my $result = $self->{client}->call($self->{url}, $self->{headers}, {
-        method => "${module.module_name}._check_job",
-        params => \@args});
-    if ($result) {
-        if ($result->is_error) {
-            Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
-                           code => $result->content->{error}->{code},
-                           method_name => '_check_job',
-                           data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
-                          );
+    my $result = $self->{ client }->call(
+        $self->{ url },
+        $self->{ headers },
+        {
+            method => "${module.module_name}._check_job",
+            params => \@args
+        }
+    );
+    if ( $result ) {
+        if ( $result->is_error ) {
+            Bio::KBase::Exceptions::JSONRPC->throw(
+                error       => $result->error_message,
+                code        => $result->content->{ error }{ code },
+                method_name => '_check_job',
+                # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+                data        => $result->content->{ error }{ error },
+            );
         } else {
             return $result->result->[0];
         }
     } else {
-        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method _check_job",
-                        status_line => $self->{client}->status_line,
-                        method_name => '_check_job');
+        Bio::KBase::Exceptions::HTTP->throw(
+            error       => "Error invoking method _check_job",
+            status_line => $self->{client}->status_line,
+            method_name => '_check_job'
+        );
     }
 }
 
@@ -227,29 +236,30 @@ ${method.doc}
 =cut
 
 #if( $method.async || $async_version)
-sub ${method.name}
-{
-    my($self, @args) = @_;
-    my $job_id = $self->_${method.name}_submit(@args);
-    my $async_job_check_time = $self->{async_job_check_time};
+sub ${method.name} {
+    my ( $self, @args ) = @_;
+    my $job_id          = $self->_${method.name}_submit( @args );
+    my $async_job_check_time = $self->{ async_job_check_time };
     while (1) {
         Time::HiRes::sleep($async_job_check_time);
-        $async_job_check_time *= $self->{async_job_check_time_scale_percent} / 100.0;
-        if ($async_job_check_time > $self->{async_job_check_max_time}) {
-            $async_job_check_time = $self->{async_job_check_max_time};
+        $async_job_check_time *= $self->{ async_job_check_time_scale_percent } / 100.0;
+        if ( $async_job_check_time > $self->{ async_job_check_max_time } ) {
+            $async_job_check_time = $self->{ async_job_check_max_time };
         }
-        my $job_state_ref = $self->_check_job($job_id);
-        if ($job_state_ref->{"finished"} != 0) {
-            if (!exists $job_state_ref->{"result"}) {
-                $job_state_ref->{"result"} = [];
+        my $job_state_ref = $self->_check_job( $job_id );
+        if ( $job_state_ref->{ "finished" } != 0 ) {
+            if ( !exists $job_state_ref->{ "result" } ) {
+                $job_state_ref->{ "result" } = [];
             }
-            return wantarray ? @{$job_state_ref->{"result"}} : $job_state_ref->{"result"}->[0];
+            return wantarray
+              ? @{ $job_state_ref->{ "result" } }
+              : $job_state_ref->{ "result" }[ 0 ];
         }
     }
 }
 
 sub _${method.name}_submit {
-    my($self, @args) = @_;
+    my ( $self, @args ) = @_;
 # Authentication: ${method.authentication}
     if ((my $n = @args) != ${method.arg_count}) {
         Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
@@ -270,132 +280,174 @@ sub _${method.name}_submit {
     }
 #end
     my $context = undef;
-    if ($self->{service_version}) {
-        $context = {'service_ver' => $self->{service_version}};
+    if ( $self->{ service_version } ) {
+        $context = { 'service_ver' => $self->{ service_version } };
     }
-    my $result = $self->{client}->call($self->{url}, $self->{headers}, {
-        method => "${module.module_name}._${method.name}_submit",
-        params => \@args, context => $context});
-    if ($result) {
-        if ($result->is_error) {
-            Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
-                           code => $result->content->{error}->{code},
-                           method_name => '_${method.name}_submit',
-                           data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+    my $result = $self->{ client }->call(
+        $self->{ url },
+        $self->{ headers },
+        {
+            method  => "${module.module_name}._${method.name}_submit",
+            params  => \@args,
+            context => $context
+        }
+    );
+
+    if ( $result ) {
+        if ( $result->is_error ) {
+            Bio::KBase::Exceptions::JSONRPC->throw(
+                error       => $result->error_message,
+                code        => $result->content->{ error }{ code },
+                method_name => '_${method.name}_submit',
+                # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+                data        => $result->content->{ error }{ error },
             );
         } else {
             return $result->result->[0];  # job_id
         }
     } else {
-        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method _${method.name}_submit",
-                        status_line => $self->{client}->status_line,
-                        method_name => '_${method.name}_submit');
+        Bio::KBase::Exceptions::HTTP->throw(
+            error       => "Error invoking method _${method.name}_submit",
+            status_line => $self->{ client }->status_line,
+            method_name => '_${method.name}_submit'
+        );
     }
 }
 
 #else ## of if-any-async
-sub ${method.name}
-{
-    my($self, @args) = @_;
+sub ${method.name} {
+    my ( $self, @args ) = @_;
 
 # Authentication: ${method.authentication}
 
-    if ((my $n = @args) != ${method.arg_count})
-    {
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
-							       "Invalid argument count for function ${method.name} (received $n, expecting ${method.arg_count})");
+    if ( ( my $n = @args ) != ${method.arg_count} ) {
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error => "Invalid argument count for function ${method.name} (received $n, expecting ${method.arg_count})"
+        );
     }
 #if( $method.arg_count > 0 )
     {
-	my(${method.arg_vars}) = @args;
+        my( ${method.arg_vars} ) = @args;
 
-	my @_bad_arguments;
+        my @_bad_arguments;
 #foreach( $param in $method.params )
-        (${param.validator}) or push(@_bad_arguments, "Invalid type for argument ${param.index} \"${param.name}\" (value was \"${param.perl_var}\")");
+        ( ${param.validator} ) or push( @_bad_arguments, "Invalid type for argument ${param.index} \"${param.name}\" (value was \"${param.perl_var}\")" );
 #end
-        if (@_bad_arguments) {
-	    my $msg = "Invalid arguments passed to ${method.name}:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-								   method_name => '${method.name}');
-	}
+        if ( @_bad_arguments ) {
+            my $msg = "Invalid arguments passed to ${method.name}:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+            Bio::KBase::Exceptions::ArgumentValidationError->throw(
+                error       => $msg,
+                method_name => '${method.name}'
+            );
+        }
     }
 #end
 
 #if( $dynserv_ver )
-    my $service_state = $self->{client}->call($self->{url}, $self->{headers}, {
-        method => "ServiceWizard.get_service_status",
-        params => [{module_name=>"${module.module_name}", version=>$self->{service_version}}]});
-    if ($service_state->is_error) {
-        Bio::KBase::Exceptions::JSONRPC->throw(error => $service_state->error_message,
-                           code => $service_state->content->{error}->{code},
-                           method_name => 'ServiceWizard.get_service_status',
-                           data => $service_state->content->{error}->{error}
-                          );
+    my $service_state = $self->{ client }->call(
+        $self->{ url },
+        $self->{ headers },
+        {
+            method => "ServiceWizard.get_service_status",
+            params =>
+            [
+              {
+                module_name => "${module.module_name}",
+                version     => $self->{ service_version }
+              }
+            ]
+        }
+    );
+    if ( $service_state->is_error ) {
+        Bio::KBase::Exceptions::JSONRPC->throw(
+            error       => $service_state->error_message,
+            code        => $service_state->content->{ error }{ code },
+            method_name => 'ServiceWizard.get_service_status',
+            data        => $service_state->content->{ error }{ error }
+        );
     }
     my $url = $service_state->result->[0]->{url};
 #else
-    my $url = $self->{url};
+    my $url = $self->{ url };
 #end
-    my $result = $self->{client}->call($url, $self->{headers}, {
-	    method => "${module.module_name}.${method.name}",
-	    params => \@args,
-    });
-    if ($result) {
-	if ($result->is_error) {
-	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
-					       code => $result->content->{error}->{code},
-					       method_name => '${method.name}',
-					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
-					      );
-	} else {
+    my $result = $self->{ client }->call(
+        $url,
+        $self->{ headers },
+        {
+            method => "${module.module_name}.${method.name}",
+            params => \@args,
+        }
+    );
+    if ( $result ) {
+        if ( $result->is_error ) {
+            Bio::KBase::Exceptions::JSONRPC->throw(
+                error       => $result->error_message,
+                code        => $result->content->{ error }{ code },
+                method_name => '${method.name}',
+                # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+                data        => $result->content->{ error }{ error },
+            );
+        } else {
 #if( $method.ret_count > 0 )
-	    return wantarray ? @{$result->result} : $result->result->[0];
+            return wantarray ? @{ $result->result } : $result->result->[ 0 ];
 #else
-	    return;
+            return;
 #end
-	}
+        }
     } else {
-        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method ${method.name}",
-					    status_line => $self->{client}->status_line,
-					    method_name => '${method.name}',
-				       );
+        Bio::KBase::Exceptions::HTTP->throw(
+            error       => "Error invoking method ${method.name}",
+            status_line => $self->{ client }->status_line,
+            method_name => '${method.name}',
+        );
     }
 }
+
 #end ## of if-any-async
 
-#end ## of foreach-method 
+#end ## of foreach-method
 #if( !$status_in_kidl )
 #if( $async_version )
 
-sub status
-{
-    my($self, @args) = @_;
+sub status {
+    my ( $self, @args ) = @_;
     my $job_id = undef;
-    if ((my $n = @args) != 0) {
-        Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
-                                   "Invalid argument count for function status (received $n, expecting 0)");
+    if ( ( my $n = @args ) != 0 ) {
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error => "Invalid argument count for function status (received $n, expecting 0)");
     }
     my $context = undef;
-    if ($self->{service_version}) {
-        $context = {'service_ver' => $self->{service_version}};
+    if ( $self->{ service_version } ) {
+        $context = { 'service_ver' => $self->{ service_version } };
     }
-    my $result = $self->{client}->call($self->{url}, $self->{headers}, {
-        method => "${module.module_name}._status_submit",
-        params => \@args, context => $context});
-    if ($result) {
-        if ($result->is_error) {
-            Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
-                           code => $result->content->{error}->{code},
-                           method_name => '_status_submit',
-                           data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+    my $result = $self->{ client }->call(
+        $self->{ url },
+        $self->{ headers },
+        {
+            method  => "${module.module_name}._status_submit",
+            params  => \@args,
+            context => $context
+        }
+    );
+
+    if ( $result ) {
+        if ( $result->is_error ) {
+            Bio::KBase::Exceptions::JSONRPC->throw(
+                error       => $result->error_message,
+                code        => $result->content->{ error }{ code },
+                method_name => '_status_submit',
+                # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+                data        => $result->content->{ error }{ error },
             );
         } else {
             $job_id = $result->result->[0];
         }
     } else {
-        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method _status_submit",
-                        status_line => $self->{client}->status_line,
-                        method_name => '_status_submit');
+        Bio::KBase::Exceptions::HTTP->throw(
+            error       => "Error invoking method _status_submit",
+            status_line => $self->{ client }->status_line,
+            method_name => '_status_submit',
+        );
     }
     my $async_job_check_time = $self->{async_job_check_time};
     while (1) {
@@ -415,47 +467,67 @@ sub status
 }
 #else ## of if-status-async
 
-sub status
-{
-    my($self, @args) = @_;
+sub status {
+    my ( $self, @args ) = @_;
+
     if ((my $n = @args) != 0) {
-        Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
-                                   "Invalid argument count for function status (received $n, expecting 0)");
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error => "Invalid argument count for function status (received $n, expecting 0)");
     }
 #if( $dynserv_ver )
-    my $service_state = $self->{client}->call($self->{url}, $self->{headers}, {
-        method => "ServiceWizard.get_service_status",
-        params => [{module_name=>"${module.module_name}", version=>$self->{service_version}}]});
-    if ($service_state->is_error) {
-        Bio::KBase::Exceptions::JSONRPC->throw(error => $service_state->error_message,
-                           code => $service_state->content->{error}->{code},
-                           method_name => 'ServiceWizard.get_service_status',
-                           data => $service_state->content->{error}->{error}
-                          );
+
+    my $service_state = $self->{ client }->call(
+        $self->{ url },
+        $self->{ headers },
+        {
+            method => "ServiceWizard.get_service_status",
+            params =>
+            [
+              {
+                module_name => "${module.module_name}",
+                version     => $self->{ service_version }
+              }
+            ]
+        }
+    );
+    if ( $service_state->is_error ) {
+        Bio::KBase::Exceptions::JSONRPC->throw(
+            error       => $service_state->error_message,
+            code        => $service_state->content->{ error }{ code },
+            method_name => 'ServiceWizard.get_service_status',
+            data        => $service_state->content->{ error }{ error },
+        );
     }
-    my $url = $service_state->result->[0]->{url};
+    my $url = $service_state->result->[ 0 ]{ url };
 #else
-    my $url = $self->{url};
+    my $url = $self->{ url };
 #end
-    my $result = $self->{client}->call($url, $self->{headers}, {
-        method => "${module.module_name}.status",
-        params => \@args,
-    });
-    if ($result) {
-        if ($result->is_error) {
-            Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
-                           code => $result->content->{error}->{code},
-                           method_name => 'status',
-                           data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+    my $result = $self->{ client }->call(
+        $url,
+        $self->{ headers },
+        {
+            method => "${module.module_name}.status",
+            params => \@args,
+        }
+    );
+    if ( $result ) {
+        if ( $result->is_error ) {
+            Bio::KBase::Exceptions::JSONRPC->throw(
+                error       => $result->error_message,
+                code        => $result->content->{ error }{ code },
+                method_name => 'status',
+                # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+                data        => $result->content->{ error }{ error },
                           );
         } else {
-            return wantarray ? @{$result->result} : $result->result->[0];
+            return wantarray ? @{ $result->result } : $result->result->[0];
         }
     } else {
-        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method status",
-                        status_line => $self->{client}->status_line,
-                        method_name => 'status',
-                       );
+        Bio::KBase::Exceptions::HTTP->throw(
+            error       => "Error invoking method status",
+            status_line => $self->{ client }->status_line,
+            method_name => 'status',
+        );
     }
 }
 #end ## of if-status-async
@@ -464,25 +536,29 @@ sub status
 
 
 sub version {
-    my ($self) = @_;
-    my $result = $self->{client}->call($self->{url}, $self->{headers}, {
-        method => "${last_module.module_name}.version",
-        params => [],
-    });
-    if ($result) {
-        if ($result->is_error) {
+    my ( $self ) = @_;
+    my $result = $self->{client}->call(
+        $self->{ url },
+        $self->{ headers },
+        {
+            method => "${last_module.module_name}.version",
+            params => [],
+        }
+    );
+    if ( $result ) {
+        if ( $result->is_error ) {
             Bio::KBase::Exceptions::JSONRPC->throw(
-                error => $result->error_message,
-                code => $result->content->{code},
+                error       => $result->error_message,
+                code        => $result->content->{ code },
                 method_name => '${last_method.name}',
             );
         } else {
-            return wantarray ? @{$result->result} : $result->result->[0];
+            return wantarray ? @{ $result->result } : $result->result->[ 0 ];
         }
     } else {
         Bio::KBase::Exceptions::HTTP->throw(
-            error => "Error invoking method ${last_method.name}",
-            status_line => $self->{client}->status_line,
+            error       => "Error invoking method ${last_method.name}",
+            status_line => $self->{ client }->status_line,
             method_name => '${last_method.name}',
         );
     }
@@ -492,26 +568,30 @@ sub _validate_version {
     my ($self) = @_;
     my $svr_version = $self->version();
     my $client_version = $VERSION;
-    my ($cMajor, $cMinor) = split(/\./, $client_version);
-    my ($sMajor, $sMinor) = split(/\./, $svr_version);
-    if ($sMajor != $cMajor) {
+    my ( $cMajor, $cMinor ) = split(/\./, $client_version);
+    my ( $sMajor, $sMinor ) = split(/\./, $svr_version);
+
+    if ( $sMajor != $cMajor ) {
         Bio::KBase::Exceptions::ClientServerIncompatible->throw(
-            error => "Major version numbers differ.",
-            server_version => $svr_version,
-            client_version => $client_version
+            error           => "Major version numbers differ.",
+            server_version  => $svr_version,
+            client_version  => $client_version
         );
     }
-    if ($sMinor < $cMinor) {
+
+    if ( $sMinor < $cMinor ) {
         Bio::KBase::Exceptions::ClientServerIncompatible->throw(
-            error => "Client minor version greater than Server minor version.",
-            server_version => $svr_version,
-            client_version => $client_version
+            error           => "Client minor version greater than server minor version.",
+            server_version  => $svr_version,
+            client_version  => $client_version
         );
     }
-    if ($sMinor > $cMinor) {
+
+    if ( $sMinor > $cMinor ) {
         warn "New client version available for ${client_package_name}\n";
     }
-    if ($sMajor == 0) {
+
+    if ( $sMajor == 0 ) {
         warn "${client_package_name} version is $svr_version. API subject to change.\n";
     }
 }
@@ -580,61 +660,58 @@ sub call {
 #end
 
     {
-	if ($uri =~ /\?/) {
-	    $result = $self->_get($uri);
-	}
-	else {
-	    Carp::croak "not hashref." unless (ref $obj eq 'HASH');
-	    $result = $self->_post($uri, $headers, $obj);
-	}
-#if( $enable_client_retry )
-
-	#
-	# Bail early on success.
-	#
-	if ($result->is_success)
-	{
-	    if ($n_retries)
-	    {
-		print STDERR strftime("%F %T", localtime), ": Request succeeded after $n_retries retries\n";
-	    }
-	    last;
-	}
-	$n_retries++;
-
-	#
-	# Failure. See if we need to retry and loop, or bail with
-	# a permanent failure.
-	#
-	
-        my $code = $result->code;
-	my $msg = $result->message;
-	my $want_retry = 0;
-	if ($codes_to_retry${empty_escaper}{$code})
-	{
-	    $want_retry = 1;
-	}
-	elsif ($code eq 500 && defined( $result->header('client-warning') )
-	       && $result->header('client-warning') eq 'Internal response')
-	{
-	    #
-	    # Handle errors that were not thrown by the web
-	    # server but rather picked up by the client library.
-	    #
-	    # If we got a client timeout or connection refused, let us retry.
-	    #
-	    
-	    if ($msg =~ /timeout|connection refused/i)
-	    {
-		$want_retry = 1;
-	    }
-	    
-	}
-	
-        if (!$want_retry || @retries == 0) {
-	    last;
+        if ($uri =~ /\?/) {
+            $result = $self->_get($uri);
         }
-	
+        else {
+            Carp::croak "not hashref." unless (ref $obj eq 'HASH');
+            $result = $self->_post($uri, $headers, $obj);
+        }
+        #if( $enable_client_retry )
+
+        #
+        # Bail early on success.
+        #
+        if ($result->is_success) {
+            if ($n_retries) {
+                print STDERR strftime("%F %T", localtime), ": Request succeeded after $n_retries retries\n";
+            }
+            last;
+        }
+        $n_retries++;
+
+        #
+        # Failure. See if we need to retry and loop, or bail with
+        # a permanent failure.
+        #
+
+        my $code = $result->code;
+        my $msg = $result->message;
+        my $want_retry = 0;
+        if ($codes_to_retry${empty_escaper}{$code})
+        {
+            $want_retry = 1;
+        }
+        elsif ($code eq 500 && defined( $result->header('client-warning') )
+               && $result->header('client-warning') eq 'Internal response')
+        {
+            #
+            # Handle errors that were not thrown by the web
+            # server but rather picked up by the client library.
+            #
+            # If we got a client timeout or connection refused, let us retry.
+            #
+
+            if ($msg =~ /timeout|connection refused/i) {
+                $want_retry = 1;
+            }
+
+        }
+
+        if (!$want_retry || @retries == 0) {
+            last;
+        }
+
         #
         # otherwise, sleep & loop.
         #
@@ -670,13 +747,13 @@ sub call {
 
 
 sub _post {
-    my ($self, $uri, $headers, $obj) = @_;
+    my ( $self, $uri, $headers, $obj ) = @_;
     my $json = $self->json;
 
-    $obj->{version} ||= $self->{version} || '1.1';
+    $obj->{ version } ||= $self->{ version } || '1.1';
 
-    if ($obj->{version} eq '1.0') {
-        delete $obj->{version};
+    if ( $obj->{ version } eq '1.0' ) {
+        delete $obj->{ version };
         if (exists $obj->{id}) {
             $self->id($obj->{id}) if ($obj->{id}); # if undef, it is notification.
         }
@@ -685,9 +762,9 @@ sub _post {
         }
     }
     else {
-        # $obj->{id} = $self->id if (defined $self->id);
-	# Assign a random number to the id if one hasn't been set
-	$obj->{id} = (defined $self->id) ? $self->id : substr(rand(),2);
+        # $obj->{ id } = $self->id if defined $self->id;
+        # Assign a random number to the id if one hasn't been set
+        $obj->{ id } = (defined $self->id) ? $self->id : substr( rand(), 2 );
     }
 
     my $content = $json->encode($obj);
@@ -697,11 +774,9 @@ sub _post {
         Content_Type   => $self->{content_type},
         Content        => $content,
         Accept         => 'application/json',
-	@$headers,
-	($self->{token} ? (Authorization => $self->{token}) : ()),
+        @$headers,
+        ($self->{token} ? (Authorization => $self->{token}) : ()),
     );
 }
-
-
 
 1;

--- a/src/java/us/kbase/templates/perl_impl.vm.properties
+++ b/src/java/us/kbase/templates/perl_impl.vm.properties
@@ -1,6 +1,8 @@
 package ${module.impl_package_name};
 
 use strict;
+use warnings;
+
 use Bio::KBase::Exceptions;
 # Use Semantic Versioning (2.0.0-rc.1)
 # http://semver.org
@@ -43,12 +45,11 @@ ${module.module_constructor}    #END_CONSTRUCTOR
 #set( $status_in_kidl = true )
 #end
 
-
 =head2 ${method.name}
 
   #if( "$method.ret_vars" != "" )${method.ret_vars} = #{end}$obj->${method.name}(${method.arg_vars})
 
-=over 4
+=over
 
 =item Parameter and return types
 
@@ -73,7 +74,6 @@ ${docline}
 =end text
 
 
-
 =item Description
 
 ${method.doc}
@@ -85,17 +85,19 @@ ${method.doc}
 sub ${method.name} {
     my $self = shift;
 #if( $method.arg_count > 0 )
-    my( ${method.arg_vars} ) = @_;
+    my ( ${method.arg_vars} ) = @_;
 
-    my @_bad_arguments;
+    my @bad_arguments;
 #foreach( $param in $method.params )
-    ( ${param.validator} ) or push( @_bad_arguments, "Invalid type for argument \"${param.name}\" (value was \"${param.perl_var}\")" );
+    ( ${param.validator} ) or push @bad_arguments,
+        "Invalid type for argument \"${param.name}\" "
+        . "(value was \"${param.perl_var}\")";
 #end
-    if ( @_bad_arguments ) {
+    if ( @bad_arguments ) {
         my $msg = "Invalid arguments passed to ${method.name}:\n"
-            . join("", map { "\t$_\n" } @_bad_arguments);
+            . join "", map { "\t$_\n" } @bad_arguments;
         Bio::KBase::Exceptions::ArgumentValidationError->throw(
-            error => $msg,
+            error       => $msg,
             method_name => '${method.name}'
         );
     }
@@ -108,13 +110,15 @@ sub ${method.name} {
     #BEGIN ${method.name}
 ${method.user_code}    #${empty_escaper}END ${method.name}
 #if( $method.ret_count > 0 )
-    my @_bad_returns;
+    my @bad_returns;
 #foreach( $return in $method.returns )
-    (${return.validator}) or push(@_bad_returns, "Invalid type for return variable \"${return.name}\" (value was \"${return.perl_var}\")");
+    ( ${return.validator} ) or push @bad_returns,
+        "Invalid type for return variable \"${return.name}\" "
+        . "(value was \"${return.perl_var}\")";
 #end
-    if ( @_bad_returns ) {
+    if ( @bad_returns ) {
         my $msg = "Invalid returns passed to ${method.name}:\n"
-            . join( "", map { "\t$_\n" } @_bad_returns );
+            . join "", map { "\t$_\n" } @bad_returns;
         Bio::KBase::Exceptions::ArgumentValidationError->throw(
             error       => $msg,
             method_name => '${method.name}'
@@ -133,7 +137,7 @@ ${method.user_code}    #${empty_escaper}END ${method.name}
 
   $return = $obj->status()
 
-=over 4
+=over
 
 =item Parameter and return types
 
@@ -182,19 +186,16 @@ ${module.module_status}
 
 #foreach( $type in $module.types )
 
-
 =head2 ${type.name}
 
-=over 4
+=over
 
 #if( $type.comment && "$type.comment" != "" )
-
 
 =item Description
 
 ${type.comment}
 #end
-
 
 =item Definition
 
@@ -215,7 +216,6 @@ ${type.english}
 =back
 
 #end
-
 
 =cut
 

--- a/src/java/us/kbase/templates/perl_impl.vm.properties
+++ b/src/java/us/kbase/templates/perl_impl.vm.properties
@@ -1,8 +1,9 @@
 package ${module.impl_package_name};
+
 use strict;
 use Bio::KBase::Exceptions;
 # Use Semantic Versioning (2.0.0-rc.1)
-# http://semver.org 
+# http://semver.org
 our $VERSION = '${module.semantic_version}';
 our $GIT_URL = '${module.git_url}';
 our $GIT_COMMIT_HASH = '${module.git_commit_hash}';
@@ -20,18 +21,16 @@ ${module.module_doc}
 #BEGIN_HEADER
 ${module.module_header}#END_HEADER
 
-sub new
-{
-    my($class, @args) = @_;
-    my $self = {
-    };
+sub new {
+    my ( $class, @args ) = @_;
+    my $self = {};
     bless $self, $class;
+
     #BEGIN_CONSTRUCTOR
 ${module.module_constructor}    #END_CONSTRUCTOR
 
-    if ($self->can('_init_instance'))
-    {
-	$self->_init_instance();
+    if ( $self->can( '_init_instance' ) ) {
+        $self->_init_instance();
     }
     return $self;
 }
@@ -83,26 +82,28 @@ ${method.doc}
 
 =cut
 
-sub ${method.name}
-{
+sub ${method.name} {
     my $self = shift;
 #if( $method.arg_count > 0 )
-    my(${method.arg_vars}) = @_;
+    my( ${method.arg_vars} ) = @_;
 
     my @_bad_arguments;
 #foreach( $param in $method.params )
-    (${param.validator}) or push(@_bad_arguments, "Invalid type for argument \"${param.name}\" (value was \"${param.perl_var}\")");
+    ( ${param.validator} ) or push( @_bad_arguments, "Invalid type for argument \"${param.name}\" (value was \"${param.perl_var}\")" );
 #end
-    if (@_bad_arguments) {
-	my $msg = "Invalid arguments passed to ${method.name}:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => '${method.name}');
+    if ( @_bad_arguments ) {
+        my $msg = "Invalid arguments passed to ${method.name}:\n"
+            . join("", map { "\t$_\n" } @_bad_arguments);
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error => $msg,
+            method_name => '${method.name}'
+        );
     }
 #end
 
     my $ctx = $${server_package_name}::CallContext;
 #if( $method.ret_count > 0 )
-    my(${method.ret_vars});
+    my ( ${method.ret_vars} );
 #end
     #BEGIN ${method.name}
 ${method.user_code}    #${empty_escaper}END ${method.name}
@@ -111,13 +112,16 @@ ${method.user_code}    #${empty_escaper}END ${method.name}
 #foreach( $return in $method.returns )
     (${return.validator}) or push(@_bad_returns, "Invalid type for return variable \"${return.name}\" (value was \"${return.perl_var}\")");
 #end
-    if (@_bad_returns) {
-	my $msg = "Invalid returns passed to ${method.name}:\n" . join("", map { "\t$_\n" } @_bad_returns);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => '${method.name}');
+    if ( @_bad_returns ) {
+        my $msg = "Invalid returns passed to ${method.name}:\n"
+            . join( "", map { "\t$_\n" } @_bad_returns );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => '${method.name}'
+        );
     }
 #end
-    return(${method.ret_vars});
+    return ( ${method.ret_vars} );
 }
 
 
@@ -125,7 +129,7 @@ ${method.user_code}    #${empty_escaper}END ${method.name}
 
 #if( !$status_in_kidl )
 
-=head2 status 
+=head2 status
 
   $return = $obj->status()
 
@@ -156,15 +160,21 @@ Return the module status. This is a structure including Semantic Versioning numb
 =cut
 
 sub status {
-    my($return);
+    my $return;
     #BEGIN_STATUS
 #if( ${module.module_status} )
-${module.module_status}#else
-    $return = {"state" => "OK", "message" => "", "version" => $VERSION,
-               "git_url" => $GIT_URL, "git_commit_hash" => $GIT_COMMIT_HASH};
+${module.module_status}
+#else
+    $return = {
+        "state"           => "OK",
+        "message"         => "",
+        "version"         => $VERSION,
+        "git_url"         => $GIT_URL,
+        "git_commit_hash" => $GIT_COMMIT_HASH
+    };
 #end
     #END_STATUS
-    return($return);
+    return ( $return );
 }
 #end
 

--- a/src/java/us/kbase/templates/perl_psgi.vm.properties
+++ b/src/java/us/kbase/templates/perl_psgi.vm.properties
@@ -7,7 +7,6 @@ use Plack::Middleware::CrossOrigin;
 
 #if( $service_options.authenticated )
 use UserAuth;
-
 my $user_auth = UserAuth->new();
 #end
 
@@ -17,18 +16,23 @@ my @dispatch;
 #foreach( $module in $modules )
 {
     my $obj = ${module.impl_package_name}->new;
-    push(@dispatch, '${module.module_name}' => $obj);
+    push( @dispatch, '${module.module_name}' => $obj );
 }
 #end
 
 
-my $server = ${server_package_name}->new(instance_dispatch => { @dispatch },
+my $server = ${server_package_name}->new(
+    instance_dispatch => { @dispatch },
+    allow_get         => 0,
 #if( $service_options.authenticated )
-				user_auth => $user_auth,
+    user_auth         => $user_auth,
 #end
-				allow_get => 0,
-			       );
+);
 
 my $handler = sub { $server->handle_input(@_) };
 
-$handler = Plack::Middleware::CrossOrigin->wrap( $handler, origins => "*", headers => "*");
+$handler    = Plack::Middleware::CrossOrigin->wrap(
+    $handler,
+    origins => "*",
+    headers => "*"
+);

--- a/src/java/us/kbase/templates/perl_psgi.vm.properties
+++ b/src/java/us/kbase/templates/perl_psgi.vm.properties
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 #foreach( $module in $modules )
 use ${module.impl_package_name};
 #end
@@ -10,19 +13,14 @@ use UserAuth;
 my $user_auth = UserAuth->new();
 #end
 
-
-my @dispatch;
-
+my %dispatch = (
 #foreach( $module in $modules )
-{
-    my $obj = ${module.impl_package_name}->new;
-    push( @dispatch, '${module.module_name}' => $obj );
-}
+    '${module.module_name}' => ${module.impl_package_name}->new,
 #end
-
+);
 
 my $server = ${server_package_name}->new(
-    instance_dispatch => { @dispatch },
+    instance_dispatch => \%dispatch,
     allow_get         => 0,
 #if( $service_options.authenticated )
     user_auth         => $user_auth,

--- a/src/java/us/kbase/templates/perl_server.vm.properties
+++ b/src/java/us/kbase/templates/perl_server.vm.properties
@@ -1,6 +1,6 @@
 package ${server_package_name};
-#set( $ctx_pkg = "${server_package_name}Context" )
 
+#set( $ctx_pkg = "${server_package_name}Context" )
 #set( $stderr_pkg = "${server_package_name}StderrWrapper" )
 
 use Data::Dumper;
@@ -21,13 +21,17 @@ use Bio::KBase::AuthToken;
 
 extends 'RPC::Any::Server::JSONRPC::PSGI';
 
-has 'instance_dispatch' => (is => 'ro', isa => 'HashRef');
-has 'user_auth' => (is => 'ro', isa => 'UserAuth');
-has 'valid_methods' => (is => 'ro', isa => 'HashRef', lazy => 1,
-			builder => '_build_valid_methods');
-has 'loggers' => (is => 'ro', required => 1, builder => '_build_loggers');
-has 'config' => (is => 'ro', required => 1, builder => '_build_config');
-has 'local_headers' => (is => 'ro', isa => 'HashRef');
+has 'instance_dispatch' => ( is => 'ro', isa => 'HashRef' );
+has 'user_auth'         => ( is => 'ro', isa => 'UserAuth' );
+has 'valid_methods'     => (
+    is      => 'ro',
+    isa     => 'HashRef',
+    lazy    => 1,
+    builder => '_build_valid_methods'
+);
+has 'loggers' => ( is => 'ro', required => 1, builder => '_build_loggers' );
+has 'config'  => ( is => 'ro', required => 1, builder => '_build_config' );
+has 'local_headers' => ( is => 'ro', isa => 'HashRef' );
 
 our $CallContext;
 
@@ -38,11 +42,11 @@ our %return_counts = (
 #if( ${method.name} == "status" )
 #set( $status_in_kidl = true )
 #end
-        '${method.name}' => ${method.ret_count},
+    '${method.name}' => ${method.ret_count},
 #end
 #end
 #if( !$status_in_kidl )
-        'status' => 1,
+    status  => 1,
 #end
 );
 
@@ -50,16 +54,15 @@ our %return_counts = (
 our %method_authentication = (
 #foreach( $module in $modules )
 #foreach( $method in $module.methods )
-        '${method.name}' => '${method.authentication}',
+    '${method.name}' => '${method.authentication}',
 #end
 #end
 );
 #end
 
-sub _build_valid_methods
-{
-    my($self) = @_;
-    my $methods = {
+sub _build_valid_methods {
+    my ( $self ) = @_;
+    my $methods  = {
 #foreach( $module in $modules )
 #set( $last_module = $module )
 #foreach( $method in $module.methods )
@@ -67,139 +70,162 @@ sub _build_valid_methods
 #end
 #end
 #if( !$status_in_kidl )
-        'status' => 1,
+        status  => 1,
 #end
     };
     return $methods;
 }
 
-my $DEPLOY = 'KB_DEPLOYMENT_CONFIG';
+my $DEPLOY  = 'KB_DEPLOYMENT_CONFIG';
 my $SERVICE = 'KB_SERVICE_NAME';
 
-sub get_config_file
-{
-    my ($self) = @_;
-    if(!defined $ENV${empty_escaper}{$DEPLOY}) {
+sub get_config_file {
+    my ( $self ) = @_;
+    if ( !defined $ENV${empty_escaper}{$DEPLOY} ) {
         return undef;
     }
     return $ENV${empty_escaper}{$DEPLOY};
 }
 
-sub get_service_name
-{
-    my ($self) = @_;
-    if(!defined $ENV${empty_escaper}{$SERVICE}) {
+sub get_service_name {
+    my ( $self ) = @_;
+    if ( !defined $ENV${empty_escaper}{$SERVICE} ) {
         return '${service_name}';
     }
     return $ENV${empty_escaper}{$SERVICE};
 }
 
-sub _build_config
-{
-    my ($self) = @_;
-    my $sn = $self->get_service_name();
-    my $cf = $self->get_config_file();
-    if (!($cf)) {
+sub _build_config {
+    my ( $self )    = @_;
+    my $sn          = $self->get_service_name;
+    my $cf          = $self->get_config_file;
+    if ( !($cf) ) {
         return {};
     }
-    my $cfg = new Config::Simple($cf);
-    my $cfgdict = $cfg->get_block($sn);
-    if (!($cfgdict)) {
+    my $cfg         = new Config::Simple( $cf );
+    my $cfgdict     = $cfg->get_block( $sn );
+    if ( !($cfgdict) ) {
         return {};
     }
     return $cfgdict;
 }
 
-sub logcallback
-{
-    my ($self) = @_;
-    $self->loggers()->{serverlog}->set_log_file(
-        $self->{loggers}->{userlog}->get_log_file());
+sub logcallback {
+    my ( $self ) = @_;
+    $self->loggers()->{ serverlog }->set_log_file(
+        $self->{ loggers }{ userlog }->get_log_file()
+    );
 }
 
-sub log
-{
-    my ($self, $level, $context, $message, $tag) = @_;
-    my $user = defined($context->user_id()) ? $context->user_id(): undef; 
-    $self->loggers()->{serverlog}->log_message($level, $message, $user, 
-        $context->module(), $context->method(), $context->call_id(),
-        $context->client_ip(), $tag);
+sub log {
+    my ( $self, $level, $context, $message, $tag ) = @_;
+    my $user
+        = defined( $context->user_id() )
+        ? $context->user_id()
+        : undef;
+    $self->loggers()->{ serverlog }->log_message(
+        $level, $message, $user, $context->module(), $context->method(),
+        $context->call_id(), $context->client_ip(), $tag
+    );
 }
 
-sub _build_loggers
-{
-    my ($self) = @_;
-    my $submod = $self->get_service_name();
-    my $loggers = {};
-    my $callback = sub {$self->logcallback();};
-    $loggers->{userlog} = Bio::KBase::Log->new(
-            $submod, {}, {ip_address => 1, authuser => 1, module => 1,
-            method => 1, call_id => 1, changecallback => $callback,
-	    tag => 1,
-            config => $self->get_config_file()});
-    $loggers->{serverlog} = Bio::KBase::Log->new(
-            $submod, {}, {ip_address => 1, authuser => 1, module => 1,
-            method => 1, call_id => 1,
-	    tag => 1,
-            logfile => $loggers->{userlog}->get_log_file()});
-    $loggers->{serverlog}->set_log_level(6);
+sub _build_loggers {
+    my ( $self ) = @_;
+    my $submod   = $self->get_service_name();
+    my $loggers  = {};
+    my $callback = sub { $self->logcallback(); };
+    $loggers->{ userlog } = Bio::KBase::Log->new(
+        $submod,
+        {},
+        {
+            ip_address     => 1,
+            authuser       => 1,
+            module         => 1,
+            method         => 1,
+            call_id        => 1,
+            changecallback => $callback,
+            tag            => 1,
+            config         => $self->get_config_file()
+        }
+    );
+    $loggers->{ serverlog } = Bio::KBase::Log->new(
+        $submod,
+        {},
+        {
+            ip_address => 1,
+            authuser   => 1,
+            module     => 1,
+            method     => 1,
+            call_id    => 1,
+            tag        => 1,
+            logfile    => $loggers->{ userlog }->get_log_file()
+        }
+    );
+    $loggers->{ serverlog }->set_log_level( 6 );
     return $loggers;
 }
 
 #override of RPC::Any::Server
 sub handle_error {
-    my ($self, $error) = @_;
-    
-    unless (ref($error) eq 'HASH' ||
-           (blessed $error and $error->isa('RPC::Any::Exception'))) {
-        $error = RPC::Any::Exception::PerlError->new(message => $error);
+    my ( $self, $error ) = @_;
+
+    unless ( ref( $error ) eq 'HASH'
+        || ( blessed $error and $error->isa( 'RPC::Any::Exception' ) ) ) {
+        $error = RPC::Any::Exception::PerlError->new( message => $error );
     }
     my $output;
     eval {
-        my $encoded_error = $self->encode_output_from_exception($error);
-        $output = $self->produce_output($encoded_error);
+        my $encoded_error = $self->encode_output_from_exception( $error );
+        $output = $self->produce_output( $encoded_error );
     };
-    
+
     return $output if $output;
-    
+
     die "$error\n\nAlso, an error was encountered while trying to send"
         . " this error: $@\n";
 }
 
 #override of RPC::Any::JSONRPC
 sub encode_output_from_exception {
-    my ($self, $exception) = @_;
+    my ( $self, $exception ) = @_;
+
     my %error_params;
-    if (ref($exception) eq 'HASH') {
-        %error_params = %{$exception};
-        if(defined($error_params${empty_escaper}{context})) {
+
+    if ( ref $exception eq 'HASH' ) {
+        %error_params = %$exception;
+        if ( defined( $error_params${empty_escaper}{ context } ) ) {
             my @errlines;
-            $errlines[0] = $error_params${empty_escaper}{message};
-            push @errlines, split("\n", $error_params${empty_escaper}{data});
-            $self->log($Bio::KBase::Log::ERR, $error_params${empty_escaper}{context}, \@errlines);
-            delete $error_params${empty_escaper}{context};
+            $errlines[0] = $error_params${empty_escaper}{ message };
+            push @errlines, split( "\n", $error_params${empty_escaper}{ data } );
+            $self->log(
+              $Bio::KBase::Log::ERR,
+              $error_params${empty_escaper}{ context },
+              \@errlines
+            );
+            delete $error_params${empty_escaper}{ context };
         }
-    } else {
+    }
+    else {
         %error_params = (
             message => $exception->message,
             code    => $exception->code,
         );
     }
     my $json_error;
-    if ($self->_last_call) {
-        $json_error = $self->_last_call->return_error(%error_params);
+    if ( $self->_last_call ) {
+        $json_error = $self->_last_call->return_error( %error_params );
     }
     # Default to default_version. This happens when we throw an exception
     # before inbound parsing is complete.
     else {
-        $json_error = $self->_default_error(%error_params);
+        $json_error = $self->_default_error( %error_params );
     }
-    return $self->encode_output_from_object($json_error);
+    return $self->encode_output_from_object( $json_error );
 }
 
 sub trim {
-    my ($str) = @_;
-    if (!(defined $str)) {
+    my ( $str ) = @_;
+    if ( !( defined $str ) ) {
         return $str;
     }
     $str =~ s/^\s+|\s+$//g;
@@ -207,264 +233,289 @@ sub trim {
 }
 
 sub getIPAddress {
-    my ($self) = @_;
-    my $xFF = trim($self->_plack_req_header("X-Forwarded-For"));
-    my $realIP = trim($self->_plack_req_header("X-Real-IP"));
-    my $nh = $self->config->{"dont_trust_x_ip_headers"};
-    my $trustXHeaders = !(defined $nh) || $nh ne "true";
+    my ( $self )      = @_;
+    my $xFF           = trim( $self->_plack_req_header( "X-Forwarded-For" ) );
+    my $realIP        = trim( $self->_plack_req_header( "X-Real-IP" ) );
+    my $nh            = $self->config->{ "dont_trust_x_ip_headers" };
+    my $trustXHeaders = !( defined $nh ) || $nh ne "true";
 
-    if ($trustXHeaders) {
-        if ($xFF) {
-            my @tmp = split(",", $xFF);
-            return trim($tmp[0]);
+    if ( $trustXHeaders ) {
+        if ( $xFF ) {
+            my @tmp = split ",", $xFF;
+            return trim( $tmp[ 0 ] );
         }
-        if ($realIP) {
+        if ( $realIP ) {
             return $realIP;
         }
     }
-    if (defined($self->_plack_req)) {
+    if ( defined( $self->_plack_req ) ) {
         return $self->_plack_req->address;
     }
     return "localhost";
 }
 
 sub call_method {
-    my ($self, $data, $method_info) = @_;
+    my ( $self, $data, $method_info ) = @_;
 
-    my ($module, $method, $modname) = @$method_info${empty_escaper}{qw(module method modname)};
-    
-    my $ctx = ${ctx_pkg}->new($self->{loggers}->{userlog},
-                           client_ip => $self->getIPAddress());
-    $ctx->module($modname);
-    $ctx->method($method);
-    $ctx->call_id($self->{_last_call}->{id});
-    
-    my $args = $data->{arguments};
-    my $prov_action = {'service' => $modname, 'method' => $method, 'method_params' => $args};
-    $ctx->provenance([$prov_action]);
+    my ( $module, $method, $modname ) = @$method_info${empty_escaper}{ qw( module method modname ) };
+
+    my $ctx = ${ctx_pkg}->new(
+        $self->{ loggers }{ userlog },
+        client_ip => $self->getIPAddress()
+    );
+    $ctx->module( $modname );
+    $ctx->method( $method );
+    $ctx->call_id( $self->{ _last_call }{ id } );
+
+    my $args = $data->{ arguments };
+    my $prov_action = {
+        service         => $modname,
+        method          => $method,
+        method_params   => $args
+    };
+
+    $ctx->provenance( [ $prov_action ] );
+
 #if( $authenticated )
 {
     # Service ${service_name} requires authentication.
 
-    my $method_auth = $method_authentication${empty_escaper}{$method};
-    $ctx->authenticated(0);
-    if ($method_auth eq 'none')
-    {
-	# No authentication required here. Move along.
+    my $method_auth = $method_authentication${empty_escaper}{ $method };
+    $ctx->authenticated( 0 );
+    if ( $method_auth eq 'none' ) {
+        # No authentication required here. Move along.
     }
-    else
-    {
-	my $token = $self->_plack_req_header("Authorization");
+    else {
+        my $token = $self->_plack_req_header( "Authorization" );
 
-	if (!$token && $method_auth eq 'required')
-	{
-	    $self->exception('PerlError', "Authentication required for ${last_module.module_name} but no authentication header was passed");
-	}
-
-	my $auth_token;
-        if ($self->config->{'auth-service-url'})
-        {
-            $auth_token = Bio::KBase::AuthToken->new(token => $token, ignore_authrc => 1, auth_svc=>$self->config->{'auth-service-url'});
-        } else {
-            $auth_token = Bio::KBase::AuthToken->new(token => $token, ignore_authrc => 1);
+        if ( !$token && $method_auth eq 'required' ) {
+            $self->exception( 'PerlError',
+                "Authentication required for ${last_module.module_name} but no authentication header was passed"
+            );
         }
 
-	my $valid = $auth_token->validate();
-	# Only throw an exception if authentication was required and it fails
-	if ($method_auth eq 'required' && !$valid)
-	{
-	    $self->exception('PerlError', "Token validation failed: " . $auth_token->error_message);
-	} elsif ($valid) {
-	    $ctx->authenticated(1);
-	    $ctx->user_id($auth_token->user_id);
-	    $ctx->token( $token);
-	}
+        my $auth_token;
+        if ( $self->config->{ 'auth-service-url' } ) {
+            $auth_token = Bio::KBase::AuthToken->new(
+                token         => $token,
+                ignore_authrc => 1,
+                auth_svc      =>$self->config->{ 'auth-service-url' }
+            );
+        } else {
+            $auth_token = Bio::KBase::AuthToken->new(
+                token         => $token,
+                ignore_authrc => 1
+            );
+        }
+        my $valid = $auth_token->validate();
+
+        # Only throw an exception if authentication was required and it fails
+        if ( $method_auth eq 'required' && !$valid ) {
+            $self->exception( 'PerlError',
+                "Token validation failed: "
+                . $auth_token->error_message
+            );
+        }
+        elsif ( $valid ) {
+            $ctx->authenticated( 1 );
+            $ctx->user_id( $auth_token->user_id );
+            $ctx->token( $token );
+        }
     }
 }
 #else
     # Service ${service_name} does not require authentication.
 #end
-    my $new_isa = $self->get_package_isa($module);
+    my $new_isa = $self->get_package_isa( $module );
     no strict 'refs';
     local @{"${module}::ISA"} = @$new_isa;
     local $CallContext = $ctx;
     my @result;
     {
-        # 
+        #
         # Process tag and metadata information if present.
         #
-        my $tag = $self->_plack_req_header("Kbrpc-Tag");
-        if (!$tag)
-        {
+        my $tag = $self->_plack_req_header( "Kbrpc-Tag" );
+        if ( !$tag ) {
             my ($t, $us) = &$get_time();
-            $us = sprintf("%06d", $us);
-            my $ts = strftime("%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t);
-            $tag = "S:$self->{hostname}:$$:$ts";
+            $us          = sprintf( "%06d", $us );
+            my $ts       = strftime( "%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t );
+            $tag         = "S:$self->{hostname}:$$:$ts";
         }
-        local $ENV${empty_escaper}{KBRPC_TAG} = $tag;
-        my $kb_metadata = $self->_plack_req_header("Kbrpc-Metadata");
-        my $kb_errordest = $self->_plack_req_header("Kbrpc-Errordest");
-        local $ENV${empty_escaper}{KBRPC_METADATA} = $kb_metadata if $kb_metadata;
-        local $ENV${empty_escaper}{KBRPC_ERROR_DEST} = $kb_errordest if $kb_errordest;
+        local $ENV${empty_escaper}{ KBRPC_TAG } = $tag;
+        my $kb_metadata  = $self->_plack_req_header( "Kbrpc-Metadata" );
+        my $kb_errordest = $self->_plack_req_header( "Kbrpc-Errordest" );
+        local $ENV${empty_escaper}{ KBRPC_METADATA }    = $kb_metadata  if $kb_metadata;
+        local $ENV${empty_escaper}{ KBRPC_ERROR_DEST }  = $kb_errordest if $kb_errordest;
 
-        my $stderr = ${stderr_pkg}->new($ctx, $get_time);
-        $ctx->stderr($stderr);
+        my $stderr = ${stderr_pkg}->new( $ctx, $get_time );
+        $ctx->stderr( $stderr );
 
-        my $xFF = $self->_plack_req_header("X-Forwarded-For");
-        if ($xFF) {
-            $self->log($Bio::KBase::Log::INFO, $ctx,
-                "X-Forwarded-For: " . $xFF, $tag);
+        my $xFF = $self->_plack_req_header( "X-Forwarded-For" );
+        if ( $xFF ) {
+            $self->log(
+                $Bio::KBase::Log::INFO,
+                $ctx,
+                "X-Forwarded-For: " . $xFF,
+                $tag
+            );
         }
-	
+
         my $err;
         eval {
-            $self->log($Bio::KBase::Log::INFO, $ctx, "start method", $tag);
-            local $SIG${empty_escaper}{__WARN__} = sub {
-                my($msg) = @_;
-                $stderr->log($msg);
+            $self->log( $Bio::KBase::Log::INFO, $ctx, "start method", $tag );
+            local $SIG${empty_escaper}{ __WARN__ } = sub {
+                my ( $msg ) = @_;
+                $stderr->log( $msg );
                 print STDERR $msg;
             };
 
-            @result = $module->$method(@{ $data->{arguments} });
-            $self->log($Bio::KBase::Log::INFO, $ctx, "end method", $tag);
+            @result = $module->$method( @{ $data->{ arguments } } );
+            $self->log( $Bio::KBase::Log::INFO, $ctx, "end method", $tag );
         };
 
         if ($@)
         {
             my $err = $@;
-            $stderr->log($err);
-            $ctx->stderr(undef);
+            $stderr->log( $err );
+            $ctx->stderr( undef );
             undef $stderr;
-            $self->log($Bio::KBase::Log::INFO, $ctx, "fail method", $tag);
+            $self->log( $Bio::KBase::Log::INFO, $ctx, "fail method", $tag );
             my $nicerr;
-            if(ref($err) eq "Bio::KBase::Exceptions::KBaseException") {
-                $nicerr = {code => -32603, # perl error from RPC::Any::Exception
-                           message => $err->error,
-                           data => $err->trace->as_string,
-                           context => $ctx
-                           };
-            } else {
+
+            if ( ref( $err ) eq "Bio::KBase::Exceptions::KBaseException" ) {
+                $nicerr = {
+                    code    => -32603, # perl error from RPC::Any::Exception
+                    message => $err->error,
+                    data    => $err->trace->as_string,
+                    context => $ctx
+                };
+            }
+            else {
                 my $str = "$err";
-                $str =~ s/Bio::KBase::CDMI::Service::call_method.*//s; # is this still necessary? not sure
+                # is this still necessary? not sure
+                $str    =~ s/Bio::KBase::CDMI::Service::call_method.*//s;
                 my $msg = $str;
-                $msg =~ s/ at [^\s]+.pm line \d+.\n$//;
-                $nicerr =  {code => -32603, # perl error from RPC::Any::Exception
-                            message => $msg,
-                            data => $str,
-                            context => $ctx
-                            };
+                $msg    =~ s/ at [^\s]+.pm line \d+.\n$//;
+                $nicerr =  {
+                    code    => -32603, # perl error from RPC::Any::Exception
+                    message => $msg,
+                    data    => $str,
+                    context => $ctx
+                };
             }
             die $nicerr;
         }
-        $ctx->stderr(undef);
+        $ctx->stderr( undef );
         undef $stderr;
     }
     my $result;
-    if ($return_counts${empty_escaper}{$method} == 1)
-    {
-        $result = [[$result[0]]];
+    if ( $return_counts${empty_escaper}{ $method } == 1 ) {
+        $result = [ [ $result[ 0 ] ] ];
     }
-    else
-    {
+    else {
         $result = \@result;
     }
     return $result;
 }
 
 sub _plack_req_header {
-    my ($self, $header_name) = @_;
-    if (defined($self->local_headers)) {
-        return $self->local_headers->{$header_name};
+    my ( $self, $header_name ) = @_;
+    if ( defined( $self->local_headers ) ) {
+        return $self->local_headers->{ $header_name };
     }
-    return $self->_plack_req->header($header_name);
+    return $self->_plack_req->header( $header_name );
 }
 
-sub get_method
-{
-    my ($self, $data) = @_;
-    
-    my $full_name = $data->{method};
-    
+sub get_method {
+    my ( $self, $data ) = @_;
+
+    my $full_name = $data->{ method };
+
     $full_name =~ /^(\S+)\.([^\.]+)$/;
-    my ($package, $method) = ($1, $2);
-    
-    if (!$package || !$method) {
-	$self->exception('NoSuchMethod',
-			 "'$full_name' is not a valid method. It must"
-			 . " contain a package name, followed by a period,"
-			 . " followed by a method name.");
+    my ( $package, $method ) = ( $1, $2 );
+
+    if ( !$package || !$method ) {
+        $self->exception( 'NoSuchMethod',
+              "'$full_name' is not a valid method. It must"
+            . " contain a package name, followed by a period,"
+            . " followed by a method name."
+        );
     }
 
-    if (!$self->valid_methods->{$method})
-    {
-	$self->exception('NoSuchMethod',
-			 "'$method' is not a valid method in service ${service_name}.");
+    if ( !$self->valid_methods->{ $method } ) {
+        $self->exception( 'NoSuchMethod',
+             "'$method' is not a valid method in service ${service_name}."
+        );
     }
-	
-    my $inst = $self->instance_dispatch->{$package};
+
+    my $inst = $self->instance_dispatch->{ $package };
     my $module;
-    if ($inst)
-    {
-	$module = $inst;
+    if ( $inst ) {
+        $module = $inst;
     }
-    else
-    {
-	$module = $self->get_module($package);
-	if (!$module) {
-	    $self->exception('NoSuchMethod',
-			     "There is no method package named '$package'.");
-	}
-	
-	Class::MOP::load_class($module);
+    else {
+        $module = $self->get_module( $package );
+        if ( ! $module ) {
+            $self->exception( 'NoSuchMethod',
+                "There is no method package named '$package'."
+            );
+        }
+
+        Class::MOP::load_class( $module );
     }
 
-    if (!$module->can($method)) {
-	$self->exception('NoSuchMethod',
-			 "There is no method named '$method' in the"
-			 . " '$package' package.");
+    if ( !$module->can( $method ) ) {
+        $self->exception( 'NoSuchMethod',
+            "There is no method named '$method' in the" . " '$package' package."
+        );
     }
-    
+
     return { module => $module, method => $method, modname => $package };
 }
 
 sub handle_input_cli {
-    my ($self, $input) = @_;
+    my ( $self, $input ) = @_;
     my $retval;
     eval {
-        #my $input_info = $self->check_input($input);
-        #my $input_object = $self->decode_input_to_object($input);
-        $self->parser->json->utf8(utf8::is_utf8($input) ? 0 : 1);
-        my $input_object = $self->parser->json_to_call($input);
-        my $data = $self->input_object_to_data($input_object);
-        #$self->fix_data($data, $input_info);
-        my $method_info = $self->get_method($data);
-        my $method_result = $self->call_method($data, $method_info);
-        my $collapsed_result = $self->collapse_result($method_result);
-        my $output_object = $self->output_data_to_object($collapsed_result);
-        $retval = $self->parser->return_to_json($output_object);
+        #my $input_info       = $self->check_input( $input );
+        #my $input_object     = $self->decode_input_to_object( $input );
+        $self->parser->json->utf8( utf8::is_utf8( $input ) ? 0 : 1 );
+        my $input_object      = $self->parser->json_to_call( $input );
+        my $data              = $self->input_object_to_data( $input_object );
+
+        #$self->fix_data( $data, $input_info );
+        my $method_info       = $self->get_method( $data );
+        my $method_result     = $self->call_method( $data, $method_info );
+        my $collapsed_result  = $self->collapse_result( $method_result );
+        my $output_object     = $self->output_data_to_object( $collapsed_result );
+        $retval               = $self->parser->return_to_json( $output_object );
     };
+
     return $retval if defined $retval;
+
     # The only way that we can get here is by something throwing an error.
-    return $self->handle_error_cli($@);
+    return $self->handle_error_cli( $@ );
 }
 
 sub handle_error_cli {
-    my ($self, $error) = @_;
+    my ( $self, $error ) = @_;
     my $output;
     eval {
         my %error_params;
-        if (ref($error) eq 'HASH') {
-            %error_params = %{$error};
-            if(defined($error_params${empty_escaper}{context})) {
+        if ( ref( $error ) eq 'HASH' ) {
+            %error_params = %$error;
+            if ( defined ( $error_params${empty_escaper}{ context } ) ) {
                 # my @errlines;
                 # $errlines[0] = $error_params${empty_escaper}{message};
                 # push @errlines, split("\n", $error_params${empty_escaper}{data});
-                # $self->log($Bio::KBase::Log::ERR, $error_params${empty_escaper}{context}, \@errlines);
-                delete $error_params${empty_escaper}{context};
+                # $self->log( $Bio::KBase::Log::ERR, $error_params${empty_escaper}{context}, \@errlines );
+                delete $error_params${empty_escaper}{ context };
             }
-        } else {
-            unless (blessed $error and $error->isa('RPC::Any::Exception')) {
-                $error = RPC::Any::Exception::PerlError->new(message => $error);
+        }
+        else {
+            unless ( blessed $error and $error->isa( 'RPC::Any::Exception' ) ) {
+                $error = RPC::Any::Exception::PerlError->new( message => $error );
             }
             %error_params = (
                 message => $error->message,
@@ -472,14 +523,16 @@ sub handle_error_cli {
             );
         }
         my $json_error;
-        if ($self->_last_call) {
-            $json_error = $self->_last_call->return_error(%error_params);
+        if ( $self->_last_call ) {
+            $json_error = $self->_last_call->return_error( %error_params );
         } else {
-            $json_error = $self->_default_error(%error_params);
+            $json_error = $self->_default_error( %error_params );
         }
-        $output = $self->parser->return_to_json($json_error);
+        $output = $self->parser->return_to_json( $json_error );
     };
+
     return $output if $output;
+
     die "$error\n\nAlso, an error was encountered while trying to send"
         . " this error: $@\n";
 }
@@ -503,84 +556,83 @@ is available via $context->client_ip.
 
 use base 'Class::Accessor';
 
-__PACKAGE__->mk_accessors(qw(user_id client_ip authenticated token
-                             module method call_id hostname stderr
-                             provenance));
+__PACKAGE__->mk_accessors( qw(
+        user_id client_ip authenticated token
+        module method call_id hostname stderr
+        provenance
+) );
 
-sub new
-{
-    my($class, $logger, %opts) = @_;
-    
-    my $self = {
-        %opts,
+
+sub new {
+    my ( $class, $logger, %opts ) = @_;
+
+    my $self = { %opts, };
+    chomp( $self->{ hostname } = `hostname` );
+    $self->{ hostname } ||= 'unknown-host';
+    $self->{ _logger }       = $logger;
+    $self->{ _debug_levels } = {
+        7      => 1,
+        8      => 1,
+        9      => 1,
+        DEBUG  => 1,
+        DEBUG2 => 1,
+        DEBUG3 => 1,
     };
-    chomp($self->{hostname} = `hostname`);
-    $self->{hostname} ||= 'unknown-host';
-    $self->{_logger} = $logger;
-    $self->{_debug_levels} = {7 => 1, 8 => 1, 9 => 1,
-                              'DEBUG' => 1, 'DEBUG2' => 1, 'DEBUG3' => 1};
     return bless $self, $class;
 }
 
-sub _get_user
-{
-    my ($self) = @_;
-    return defined($self->user_id()) ? $self->user_id(): undef; 
+sub _get_user {
+    my ( $self ) = @_;
+    return defined( $self->user_id() ) ? $self->user_id() : undef;
 }
 
-sub _log
-{
-    my ($self, $level, $message) = @_;
-    $self->{_logger}->log_message($level, $message, $self->_get_user(),
-        $self->module(), $self->method(), $self->call_id(),
-        $self->client_ip());
+sub _log {
+    my ( $self, $level, $message ) = @_;
+    $self->{ _logger }->log_message( $level, $message, $self->_get_user(),
+        $self->module(), $self->method(), $self->call_id(), $self->client_ip() );
 }
 
-sub log_err
-{
-    my ($self, $message) = @_;
-    $self->_log($Bio::KBase::Log::ERR, $message);
+sub log_err {
+    my ( $self, $message ) = @_;
+    $self->_log( $Bio::KBase::Log::ERR, $message );
 }
 
-sub log_info
-{
-    my ($self, $message) = @_;
-    $self->_log($Bio::KBase::Log::INFO, $message);
+sub log_info {
+    my ( $self, $message ) = @_;
+    $self->_log( $Bio::KBase::Log::INFO, $message );
 }
 
-sub log_debug
-{
-    my ($self, $message, $level) = @_;
-    if(!defined($level)) {
+sub log_debug {
+    my ( $self, $message, $level ) = @_;
+    if ( !defined( $level ) ) {
         $level = 1;
     }
-    if($self->{_debug_levels}->{$level}) {
-    } else {
-        if ($level =~ /\D/ || $level < 1 || $level > 3) {
+    if ( $self->{ _debug_levels }->{ $level } ) {
+    }
+    else {
+        if ( $level =~ /\D/ || $level < 1 || $level > 3 ) {
             die "Invalid log level: $level";
         }
         $level += 6;
     }
-    $self->_log($level, $message);
+    $self->_log( $level, $message );
 }
 
-sub set_log_level
-{
-    my ($self, $level) = @_;
-    $self->{_logger}->set_log_level($level);
+sub set_log_level {
+    my ( $self, $level ) = @_;
+    $self->{ _logger }->set_log_level( $level );
 }
 
-sub get_log_level
-{
-    my ($self) = @_;
-    return $self->{_logger}->get_log_level();
+sub get_log_level {
+    my ( $self ) = @_;
+    return $self->{ _logger }->get_log_level();
 }
 
-sub clear_log_level
-{
-    my ($self) = @_;
-    $self->{_logger}->clear_user_log_level();
+sub clear_log_level {
+    my ( $self ) = @_;
+    $self->{ _logger }->clear_user_log_level();
 }
+
 
 package ${stderr_pkg};
 
@@ -588,189 +640,157 @@ use strict;
 use POSIX;
 use Time::HiRes 'gettimeofday';
 
-sub new
-{
-    my($class, $ctx, $get_time) = @_;
-    my $self = {
-	get_time => $get_time,
-    };
-    my $dest = $ENV${empty_escaper}{KBRPC_ERROR_DEST} if exists $ENV${empty_escaper}{KBRPC_ERROR_DEST};
-    my $tag = $ENV${empty_escaper}{KBRPC_TAG} if exists $ENV${empty_escaper}{KBRPC_TAG};
-    my ($t, $us) = gettimeofday();
-    $us = sprintf("%06d", $us);
-    my $ts = strftime("%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t);
+sub new {
+    my ( $class, $ctx, $get_time ) = @_;
+    my $self        = { get_time => $get_time, };
 
-    my $name = join(".", $ctx->module, $ctx->method, $ctx->hostname, $ts);
+    my $dest        = $ENV${empty_escaper}{ KBRPC_ERROR_DEST }
+        if exists $ENV${empty_escaper}{ KBRPC_ERROR_DEST };
+    my $tag         = $ENV${empty_escaper}{ KBRPC_TAG }
+        if exists $ENV${empty_escaper}{ KBRPC_TAG };
+    my ( $t, $us )  = gettimeofday();
+    $us             = sprintf("%06d", $us);
+    my $ts          = strftime("%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t);
 
-    if ($dest && $dest =~ m,^/,)
-    {
-	#
-	# File destination
-	#
-	my $fh;
+    my $name        = join( ".", $ctx->module, $ctx->method, $ctx->hostname, $ts );
 
-	if ($tag)
-	{
-	    $tag =~ s,/,_,g;
-	    $dest = "$dest/$tag";
-	    if (! -d $dest)
-	    {
-		mkdir($dest);
-	    }
-	}
-	if (open($fh, ">", "$dest/$name"))
-	{
-	    $self->{file} = "$dest/$name";
-	    $self->{dest} = $fh;
-	}
-	else
-	{
-	    warn "Cannot open log file $dest/$name: $${empty_escaper}!";
-	}
+    if ( $dest && $dest =~ m!^/! ) {
+        #
+        # File destination
+        #
+        my $fh;
+        if ($tag) {
+            $tag =~ s,/,_,g;
+            $dest = "$dest/$tag";
+            mkdir($dest) if ! -d $dest;
+        }
+
+        if ( open($fh, ">", "$dest/$name") ) {
+            $self->{file} = "$dest/$name";
+            $self->{dest} = $fh;
+        }
+        else {
+            warn "Cannot open log file $dest/$name: $${empty_escaper}!";
+        }
     }
-    else
-    {
-	#
-	# Log to string.
-	#
-	my $stderr;
-	$self->{dest} = \$stderr;
+    else {
+        #
+        # Log to string.
+        #
+        my $stderr;
+        $self->{ dest } = \$stderr;
     }
-    
+
     bless $self, $class;
 
-    for my $e (sort { $a cmp $b } keys %ENV)
-    {
-	$self->log_cmd($e, $ENV${empty_escaper}{$e});
+    for my $e ( sort { $a cmp $b } keys %ENV ) {
+        $self->log_cmd( $e, $ENV${empty_escaper}{ $e } );
     }
     return $self;
 }
 
-sub redirect
-{
-    my($self) = @_;
-    if ($self->{dest})
-    {
-	return("2>", $self->{dest});
-    }
-    else
-    {
-	return ();
-    }
+sub redirect {
+    my ( $self ) = @_;
+
+    return () unless $self->{ dest };
+
+    return ( "2>", $self->{ dest } );
 }
 
-sub redirect_both
-{
-    my($self) = @_;
-    if ($self->{dest})
-    {
-	return(">&", $self->{dest});
-    }
-    else
-    {
-	return ();
-    }
+sub redirect_both {
+    my ( $self ) = @_;
+
+    return () unless $self->{ dest };
+
+    return ( ">&", $self->{ dest } );
 }
 
-sub timestamp
-{
-    my($self) = @_;
-    my ($t, $us) = $self->{get_time}->();
-    $us = sprintf("%06d", $us);
-    my $ts = strftime("%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t);
+sub timestamp {
+    my ( $self ) = @_;
+    my ( $t, $us ) = $self->{ get_time }->();
+    $us = sprintf( "%06d", $us );
+    my $ts = strftime( "%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t );
     return $ts;
 }
 
-sub log
-{
-    my($self, $str) = @_;
-    my $d = $self->{dest};
+sub log {
+    my ( $self, $str ) = @_;
+    my $d  = $self->{ dest };
     my $ts = $self->timestamp();
-    if (ref($d) eq 'SCALAR')
-    {
-	$$d .= "[$ts] " . $str . "\n";
-	return 1;
+    if ( ref( $d ) eq 'SCALAR' ) {
+        $$d .= "[$ts] " . $str . "\n";
+        return 1;
     }
-    elsif ($d)
-    {
-	print $d "[$ts] " . $str . "\n";
-	return 1;
+    elsif ( $d ) {
+        print $d "[$ts] " . $str . "\n";
+        return 1;
     }
     return 0;
 }
 
-sub log_cmd
-{
-    my($self, @cmd) = @_;
-    my $d = $self->{dest};
+sub log_cmd {
+    my ( $self, @cmd ) = @_;
+    my $d = $self->{ dest };
     my $str;
     my $ts = $self->timestamp();
-    if (ref($cmd[0]))
-    {
-	$str = join(" ", @{$cmd[0]});
+    if ( ref( $cmd[ 0 ] ) ) {
+        $str = join( " ", @{ $cmd[ 0 ] } );
     }
-    else
-    {
-	$str = join(" ", @cmd);
+    else {
+        $str = join( " ", @cmd );
     }
-    if (ref($d) eq 'SCALAR')
-    {
-	$$d .= "[$ts] " . $str . "\n";
+    if ( ref( $d ) eq 'SCALAR' ) {
+        $$d .= "[$ts] " . $str . "\n";
     }
-    elsif ($d)
-    {
-	print $d "[$ts] " . $str . "\n";
+    elsif ( $d ) {
+        print $d "[$ts] " . $str . "\n";
     }
-	 
+
 }
 
-sub dest
-{
-    my($self) = @_;
-    return $self->{dest};
+sub dest {
+    my ( $self ) = @_;
+    return $self->{ dest };
 }
 
-sub text_value
-{
-    my($self) = @_;
-    if (ref($self->{dest}) eq 'SCALAR')
-    {
-	my $r = $self->{dest};
-	return $$r;
+sub text_value {
+    my ( $self ) = @_;
+    if ( ref( $self->{ dest } ) eq 'SCALAR' ) {
+        my $r = $self->{ dest };
+        return $$r;
     }
-    else
-    {
-	return $self->{file};
-    }
+    return $self->{ file };
 }
 
 
-unless (caller) {
-    my($input_file,$output_file,$token) = @ARGV;
+unless ( caller ) {
+    my ( $input_file, $output_file, $token ) = @ARGV;
     my @dispatch;
 #foreach( $module in $modules )
     {
         use ${module.impl_package_name};
         my $obj = ${module.impl_package_name}->new;
-        push(@dispatch, '${module.module_name}' => $obj);
+        push( @dispatch, '${module.module_name}' => $obj );
     }
 #end
     my %headers = (
-        "Authorization" => $token,
-        "CLI" => "1"
+        Authorization   => $token,
+        CLI             => "1",
     );
     my $server = ${server_package_name}->new(
         instance_dispatch => { @dispatch },
-        allow_get => 0, 
-        local_headers => \%headers);
-    open(my $fih, '<', $input_file) or die $${empty_escaper}!;
+        allow_get         => 0,
+        local_headers     => \%headers);
+
+    open ( my $fih, '<', $input_file ) or die $${empty_escaper}!;
     my $input = '';
     while (<$fih>) {
         $input .= $_;
     }
     close $fih;
-    my $output = $server->handle_input_cli($input);
-    open(my $foh, '>', $output_file) or die "Could not open file '$output_file' $${empty_escaper}!";
+    my $output = $server->handle_input_cli( $input );
+    open ( my $foh, '>', $output_file )
+        or die "Could not open file '$output_file': $${empty_escaper}!";
     print $foh $output;
     close $foh;
 }

--- a/src/java/us/kbase/templates/perl_server.vm.properties
+++ b/src/java/us/kbase/templates/perl_server.vm.properties
@@ -102,7 +102,7 @@ sub _build_config {
     if ( !($cf) ) {
         return {};
     }
-    my $cfg         = new Config::Simple( $cf );
+    my $cfg         = Config::Simple->new( $cf );
     my $cfgdict     = $cfg->get_block( $sn );
     if ( !($cfgdict) ) {
         return {};
@@ -540,6 +540,7 @@ sub handle_error_cli {
 package ${ctx_pkg};
 
 use strict;
+use warnings;
 
 =head1 NAME
 
@@ -637,6 +638,7 @@ sub clear_log_level {
 package ${stderr_pkg};
 
 use strict;
+use warnings;
 use POSIX;
 use Time::HiRes 'gettimeofday';
 
@@ -652,7 +654,7 @@ sub new {
     $us             = sprintf("%06d", $us);
     my $ts          = strftime("%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t);
 
-    my $name        = join( ".", $ctx->module, $ctx->method, $ctx->hostname, $ts );
+    my $name        = join ".", $ctx->module, $ctx->method, $ctx->hostname, $ts;
 
     if ( $dest && $dest =~ m!^/! ) {
         #

--- a/test_scripts/perl/lib/TestImpl.pm
+++ b/test_scripts/perl/lib/TestImpl.pm
@@ -1,8 +1,9 @@
 package TestImpl;
 use strict;
 use Bio::KBase::Exceptions;
+
 # Use Semantic Versioning (2.0.0-rc.1)
-# http://semver.org 
+# http://semver.org
 our $VERSION = "0.1.0";
 
 =head1 NAME
@@ -18,18 +19,16 @@ Basic
 #BEGIN_HEADER
 #END_HEADER
 
-sub new
-{
-    my($class, @args) = @_;
-    my $self = {
-    };
+sub new {
+    my ( $class, @args ) = @_;
+    my $self = {};
     bless $self, $class;
+
     #BEGIN_CONSTRUCTOR
     #END_CONSTRUCTOR
 
-    if ($self->can('_init_instance'))
-    {
-	$self->_init_instance();
+    if ( $self->can( '_init_instance' ) ) {
+        $self->_init_instance();
     }
     return $self;
 }
@@ -74,36 +73,44 @@ $return is an int
 
 =cut
 
-sub one_simple_param
-{
+sub one_simple_param {
     my $self = shift;
-    my($val) = @_;
+    my ( $val ) = @_;
 
     my @_bad_arguments;
-    (!ref($val)) or push(@_bad_arguments, "Invalid type for argument \"val\" (value was \"$val\")");
-    if (@_bad_arguments) {
-	my $msg = "Invalid arguments passed to one_simple_param:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => 'one_simple_param');
+    ( !ref( $val ) )
+        or
+        push( @_bad_arguments, "Invalid type for argument \"val\" (value was \"$val\")" );
+    if ( @_bad_arguments ) {
+        my $msg = "Invalid arguments passed to one_simple_param:\n"
+            . join( "", map { "\t$_\n" } @_bad_arguments );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'one_simple_param'
+        );
     }
 
     my $ctx = $basicsrvServer::CallContext;
-    my($return);
+    my ( $return );
+
     #BEGIN one_simple_param
     $return = $val;
+
     #END one_simple_param
     my @_bad_returns;
-    (!ref($return)) or push(@_bad_returns, "Invalid type for return variable \"return\" (value was \"$return\")");
-    if (@_bad_returns) {
-	my $msg = "Invalid returns passed to one_simple_param:\n" . join("", map { "\t$_\n" } @_bad_returns);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => 'one_simple_param');
+    ( !ref( $return ) )
+        or push( @_bad_returns,
+        "Invalid type for return variable \"return\" (value was \"$return\")" );
+    if ( @_bad_returns ) {
+        my $msg = "Invalid returns passed to one_simple_param:\n"
+            . join( "", map { "\t$_\n" } @_bad_returns );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'one_simple_param'
+        );
     }
-    return($return);
+    return ( $return );
 }
-
-
-
 
 =head2 nothing
 
@@ -137,18 +144,15 @@ sub one_simple_param
 
 =cut
 
-sub nothing
-{
+sub nothing {
     my $self = shift;
 
     my $ctx = $basicsrvServer::CallContext;
+
     #BEGIN nothing
     #END nothing
-    return();
+    return ();
 }
-
-
-
 
 =head2 one_complex_param
 
@@ -208,36 +212,43 @@ double_number is a float
 
 =cut
 
-sub one_complex_param
-{
+sub one_complex_param {
     my $self = shift;
-    my($val2) = @_;
+    my ( $val2 ) = @_;
 
     my @_bad_arguments;
-    (ref($val2) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument \"val2\" (value was \"$val2\")");
-    if (@_bad_arguments) {
-	my $msg = "Invalid arguments passed to one_complex_param:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => 'one_complex_param');
+    ( ref( $val2 ) eq 'HASH' )
+        or push( @_bad_arguments,
+        "Invalid type for argument \"val2\" (value was \"$val2\")" );
+    if ( @_bad_arguments ) {
+        my $msg = "Invalid arguments passed to one_complex_param:\n"
+            . join( "", map { "\t$_\n" } @_bad_arguments );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'one_complex_param'
+        );
     }
 
     my $ctx = $basicsrvServer::CallContext;
-    my($return);
+    my ( $return );
+
     #BEGIN one_complex_param
-    $return = {}; #$val2;
-    #END one_complex_param
+    $return = {};    #$val2;
+                     #END one_complex_param
     my @_bad_returns;
-    (ref($return) eq 'HASH') or push(@_bad_returns, "Invalid type for return variable \"return\" (value was \"$return\")");
-    if (@_bad_returns) {
-	my $msg = "Invalid returns passed to one_complex_param:\n" . join("", map { "\t$_\n" } @_bad_returns);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => 'one_complex_param');
+    ( ref( $return ) eq 'HASH' )
+        or push( @_bad_returns,
+        "Invalid type for return variable \"return\" (value was \"$return\")" );
+    if ( @_bad_returns ) {
+        my $msg = "Invalid returns passed to one_complex_param:\n"
+            . join( "", map { "\t$_\n" } @_bad_returns );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'one_complex_param'
+        );
     }
-    return($return);
+    return ( $return );
 }
-
-
-
 
 =head2 many_simple_params
 
@@ -295,45 +306,65 @@ $return_4 is a reference to a list containing 2 items:
 
 =cut
 
-sub many_simple_params
-{
+sub many_simple_params {
     my $self = shift;
-    my($val1, $val2, $val3, $val4) = @_;
+    my ( $val1, $val2, $val3, $val4 ) = @_;
 
     my @_bad_arguments;
-    (!ref($val1)) or push(@_bad_arguments, "Invalid type for argument \"val1\" (value was \"$val1\")");
-    (!ref($val2)) or push(@_bad_arguments, "Invalid type for argument \"val2\" (value was \"$val2\")");
-    (!ref($val3)) or push(@_bad_arguments, "Invalid type for argument \"val3\" (value was \"$val3\")");
-    (ref($val4) eq 'ARRAY') or push(@_bad_arguments, "Invalid type for argument \"val4\" (value was \"$val4\")");
-    if (@_bad_arguments) {
-	my $msg = "Invalid arguments passed to many_simple_params:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => 'many_simple_params');
+    ( !ref( $val1 ) )
+        or push( @_bad_arguments,
+        "Invalid type for argument \"val1\" (value was \"$val1\")" );
+    ( !ref( $val2 ) )
+        or push( @_bad_arguments,
+        "Invalid type for argument \"val2\" (value was \"$val2\")" );
+    ( !ref( $val3 ) )
+        or push( @_bad_arguments,
+        "Invalid type for argument \"val3\" (value was \"$val3\")" );
+    ( ref( $val4 ) eq 'ARRAY' )
+        or push( @_bad_arguments,
+        "Invalid type for argument \"val4\" (value was \"$val4\")" );
+    if ( @_bad_arguments ) {
+        my $msg = "Invalid arguments passed to many_simple_params:\n"
+            . join( "", map { "\t$_\n" } @_bad_arguments );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'many_simple_params'
+        );
     }
 
     my $ctx = $basicsrvServer::CallContext;
-    my($return_1, $return_2, $return_3, $return_4);
+    my ( $return_1, $return_2, $return_3, $return_4 );
+
     #BEGIN many_simple_params
     $return_1 = $val1;
     $return_2 = $val2;
     $return_3 = $val3;
     $return_4 = $val4;
+
     #END many_simple_params
     my @_bad_returns;
-    (!ref($return_1)) or push(@_bad_returns, "Invalid type for return variable \"return_1\" (value was \"$return_1\")");
-    (!ref($return_2)) or push(@_bad_returns, "Invalid type for return variable \"return_2\" (value was \"$return_2\")");
-    (!ref($return_3)) or push(@_bad_returns, "Invalid type for return variable \"return_3\" (value was \"$return_3\")");
-    (ref($return_4) eq 'ARRAY') or push(@_bad_returns, "Invalid type for return variable \"return_4\" (value was \"$return_4\")");
-    if (@_bad_returns) {
-	my $msg = "Invalid returns passed to many_simple_params:\n" . join("", map { "\t$_\n" } @_bad_returns);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => 'many_simple_params');
+    ( !ref( $return_1 ) )
+        or push( @_bad_returns,
+        "Invalid type for return variable \"return_1\" (value was \"$return_1\")" );
+    ( !ref( $return_2 ) )
+        or push( @_bad_returns,
+        "Invalid type for return variable \"return_2\" (value was \"$return_2\")" );
+    ( !ref( $return_3 ) )
+        or push( @_bad_returns,
+        "Invalid type for return variable \"return_3\" (value was \"$return_3\")" );
+    ( ref( $return_4 ) eq 'ARRAY' )
+        or push( @_bad_returns,
+        "Invalid type for return variable \"return_4\" (value was \"$return_4\")" );
+    if ( @_bad_returns ) {
+        my $msg = "Invalid returns passed to many_simple_params:\n"
+            . join( "", map { "\t$_\n" } @_bad_returns );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'many_simple_params'
+        );
     }
-    return($return_1, $return_2, $return_3, $return_4);
+    return ( $return_1, $return_2, $return_3, $return_4 );
 }
-
-
-
 
 =head2 many_complex_params
 
@@ -397,39 +428,51 @@ complex_struct is a reference to a hash where the following keys are defined:
 
 =cut
 
-sub many_complex_params
-{
+sub many_complex_params {
     my $self = shift;
-    my($simple_val, $complex_val) = @_;
+    my ( $simple_val, $complex_val ) = @_;
 
     my @_bad_arguments;
-    (ref($simple_val) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument \"simple_val\" (value was \"$simple_val\")");
-    (ref($complex_val) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument \"complex_val\" (value was \"$complex_val\")");
-    if (@_bad_arguments) {
-	my $msg = "Invalid arguments passed to many_complex_params:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => 'many_complex_params');
+    ( ref( $simple_val ) eq 'HASH' )
+        or push( @_bad_arguments,
+        "Invalid type for argument \"simple_val\" (value was \"$simple_val\")" );
+    ( ref( $complex_val ) eq 'HASH' )
+        or push( @_bad_arguments,
+        "Invalid type for argument \"complex_val\" (value was \"$complex_val\")" );
+    if ( @_bad_arguments ) {
+        my $msg = "Invalid arguments passed to many_complex_params:\n"
+            . join( "", map { "\t$_\n" } @_bad_arguments );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'many_complex_params'
+        );
     }
 
     my $ctx = $basicsrvServer::CallContext;
-    my($return_1, $return_2);
+    my ( $return_1, $return_2 );
+
     #BEGIN many_complex_params
     $return_1 = $simple_val;
     $return_2 = $complex_val;
+
     #END many_complex_params
     my @_bad_returns;
-    (ref($return_1) eq 'HASH') or push(@_bad_returns, "Invalid type for return variable \"return_1\" (value was \"$return_1\")");
-    (ref($return_2) eq 'HASH') or push(@_bad_returns, "Invalid type for return variable \"return_2\" (value was \"$return_2\")");
-    if (@_bad_returns) {
-	my $msg = "Invalid returns passed to many_complex_params:\n" . join("", map { "\t$_\n" } @_bad_returns);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => 'many_complex_params');
+    ( ref( $return_1 ) eq 'HASH' )
+        or push( @_bad_returns,
+        "Invalid type for return variable \"return_1\" (value was \"$return_1\")" );
+    ( ref( $return_2 ) eq 'HASH' )
+        or push( @_bad_returns,
+        "Invalid type for return variable \"return_2\" (value was \"$return_2\")" );
+    if ( @_bad_returns ) {
+        my $msg = "Invalid returns passed to many_complex_params:\n"
+            . join( "", map { "\t$_\n" } @_bad_returns );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'many_complex_params'
+        );
     }
-    return($return_1, $return_2);
+    return ( $return_1, $return_2 );
 }
-
-
-
 
 =head2 with_auth
 
@@ -467,38 +510,46 @@ $return is an int
 
 =cut
 
-sub with_auth
-{
+sub with_auth {
     my $self = shift;
-    my($val1) = @_;
+    my ( $val1 ) = @_;
 
     my @_bad_arguments;
-    (!ref($val1)) or push(@_bad_arguments, "Invalid type for argument \"val1\" (value was \"$val1\")");
-    if (@_bad_arguments) {
-	my $msg = "Invalid arguments passed to with_auth:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => 'with_auth');
+    ( !ref( $val1 ) )
+        or push( @_bad_arguments,
+        "Invalid type for argument \"val1\" (value was \"$val1\")" );
+    if ( @_bad_arguments ) {
+        my $msg = "Invalid arguments passed to with_auth:\n"
+            . join( "", map { "\t$_\n" } @_bad_arguments );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'with_auth'
+        );
     }
 
     my $ctx = $basicsrvServer::CallContext;
-    my($return);
+    my ( $return );
+
     #BEGIN with_auth
     $return = $val1;
+
     #END with_auth
     my @_bad_returns;
-    (!ref($return)) or push(@_bad_returns, "Invalid type for return variable \"return\" (value was \"$return\")");
-    if (@_bad_returns) {
-	my $msg = "Invalid returns passed to with_auth:\n" . join("", map { "\t$_\n" } @_bad_returns);
-	Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-							       method_name => 'with_auth');
+    ( !ref( $return ) )
+        or push( @_bad_returns,
+        "Invalid type for return variable \"return\" (value was \"$return\")" );
+    if ( @_bad_returns ) {
+        my $msg = "Invalid returns passed to with_auth:\n"
+            . join( "", map { "\t$_\n" } @_bad_returns );
+        Bio::KBase::Exceptions::ArgumentValidationError->throw(
+            error       => $msg,
+            method_name => 'with_auth'
+        );
     }
-    return($return);
+    return ( $return );
 }
 
-
-
-
-=head2 version 
+=head2 version
 
   $return = $obj->version()
 
@@ -666,3 +717,4 @@ large_prop4 has a value which is a reference to a hash where the key is a string
 =cut
 
 1;
+

--- a/test_scripts/perl/run-client.pl
+++ b/test_scripts/perl/run-client.pl
@@ -1,9 +1,6 @@
 #
 # Automatic test rig for KBase perl client generation.
 #
-#
-#
-#
 use strict;
 use warnings;
 
@@ -11,18 +8,17 @@ use JSON;
 use Data::Dumper;
 use Getopt::Long;
 
-my $DESCRIPTION =
-"
+my $DESCRIPTION = "
 USAGE
       perl test-client.pl [options]
-      
+
 DESCRIPTION
       Conducts an automatic test of a perl client against the specified endpoint using
       methods and parameters indicated in the tests config file.
-      
+
       --endpoint [url]      endpoint of the server to test
       --token [token]       token for testing authenticated calls
-      --asyncchecktime [ms] time client waits every cycle of checking state of async methods 
+      --asyncchecktime [ms] time client waits every cycle of checking state of async methods
       --package [package]   package with client module
       --method [method]     method to run
       --input [filename]    input file with parameters in JSON
@@ -30,7 +26,7 @@ DESCRIPTION
       --error [filename]    output file with text error message
       -h, --help            display this help message, ignore all arguments
 ";
-      
+
 # first parse options to get the testconfig file
 my $verbose;
 my $endpoint;
@@ -45,111 +41,113 @@ my $error_filename;
 
 my $help;
 
-my $opt = GetOptions (
-        "verbose|v" => \$verbose,
-        "endpoint=s" => \$endpoint,
-        "token=s" => \$token,
-        "asyncchecktime=i" => \$async_job_check_time_ms,
-        "help|h" => \$help,
-        "package=s" => \$client_module,
-        "method=s" => \$method,
-        "input=s" => \$input_filename,
-        "output=s" => \$output_filename,
-        "error=s" => \$error_filename,
-        );
+my $opt = GetOptions(
+    "verbose|v"        => \$verbose,
+    "endpoint=s"       => \$endpoint,
+    "token=s"          => \$token,
+    "asyncchecktime=i" => \$async_job_check_time_ms,
+    "help|h"           => \$help,
+    "package=s"        => \$client_module,
+    "method=s"         => \$method,
+    "input=s"          => \$input_filename,
+    "output=s"         => \$output_filename,
+    "error=s"          => \$error_filename,
+);
 
-if ($help) {
-    print $DESCRIPTION."\n";
+if ( $help ) {
+    print $DESCRIPTION. "\n";
     exit 0;
 }
 
-
 # endpoint must be defined
-if (!$endpoint) {
-    fail("endpoint parameter must be defined");
+if ( !$endpoint ) {
+    fail( "endpoint parameter must be defined" );
     exit 1;
 }
 
 # package must be defined
-if (!$client_module) {
-    fail("package parameter must be defined");
+if ( !$client_module ) {
+    fail( "package parameter must be defined" );
     exit 1;
 }
 
 # method must be defined
-if (!$method) {
-    fail("method parameter must be defined");
+if ( !$method ) {
+    fail( "method parameter must be defined" );
     exit 1;
 }
 
 # input must be defined
-if (!$input_filename) {
-    fail("input parameter must be defined");
+if ( !$input_filename ) {
+    fail( "input parameter must be defined" );
     exit 1;
 }
 
 # output must be defined
-if (!$output_filename) {
-    fail("output parameter must be defined");
+if ( !$output_filename ) {
+    fail( "output parameter must be defined" );
     exit 1;
 }
 
 # error must be defined
-if (!$error_filename) {
-    fail("error parameter must be defined");
+if ( !$error_filename ) {
+    fail( "error parameter must be defined" );
     exit 1;
 }
 
 #parse the tests
-open(my $fh, "<", $input_filename);
-my $input_string='';
-while (my $line = <$fh>) {
+open( my $fh, "<", $input_filename );
+my $input_string = '';
+while ( my $line = <$fh> ) {
     chomp $line;
     $input_string .= $line;
 }
-close($fh);
-my $params = JSON->new->decode($input_string);
+close( $fh );
+my $params = JSON->new->decode( $input_string );
 
 my $json = JSON->new->canonical;
 
-eval("use $client_module;");
+eval( "use $client_module;" );
+
 #instantiate an authenticated client and a nonauthenticated client
 my $client;
 
-if($token) {
-    if ($async_job_check_time_ms) {
-        $client=$client_module->new($endpoint, token=>$token, async_job_check_time_ms=>$async_job_check_time_ms);
-    } else {
-        $client=$client_module->new($endpoint, token=>$token);
+if ( $token ) {
+    if ( $async_job_check_time_ms ) {
+        $client = $client_module->new(
+            $endpoint,
+            token                   => $token,
+            async_job_check_time_ms => $async_job_check_time_ms
+        );
     }
-} else {
-    $client = $client_module->new($endpoint,ignore_kbase_config=>1);
+    else {
+        $client = $client_module->new( $endpoint, token => $token );
+    }
+}
+else {
+    $client = $client_module->new( $endpoint, ignore_kbase_config => 1 );
 }
 
 # loop over each test case and run it against the server.  We create a new client instance
 # for each test
-    
+
 my @result;
 no strict "refs";
-eval {
-    @result = $client->$method(@{$params});
-};
-if($@) {
+eval { @result = $client->$method( @{ $params } ); };
+if ( $@ ) {
     print "caught: $@";
     my $returnedErrorMsg = "$@";
     my $OUTFILE;
     open $OUTFILE, '>>', $error_filename;
     print { $OUTFILE } $returnedErrorMsg;
     close $OUTFILE;
-} else {
-    my $serialized_result = $json->encode(\@result);
+}
+else {
+    my $serialized_result = $json->encode( \@result );
     my $OUTFILE;
     open $OUTFILE, '>>', $output_filename;
     print { $OUTFILE } $serialized_result;
     close $OUTFILE;
 }
-
-
-
 
 

--- a/test_scripts/perl/test-client.pl
+++ b/test_scripts/perl/test-client.pl
@@ -1,9 +1,6 @@
 #
 # Automatic test rig for KBase perl client generation.
 #
-#
-#
-#
 use strict;
 use warnings;
 
@@ -12,22 +9,21 @@ use Data::Dumper;
 use Test::More;
 use Getopt::Long;
 
-my $DESCRIPTION =
-"
+my $DESCRIPTION = "
 USAGE
       perl test-client.pl [options]
-      
+
 DESCRIPTION
       Conducts an automatic test of a perl client against the specified endpoint using
       methods and parameters indicated in the tests config file.
-      
+
       --tests [filename] config file for tests
       --endpoint [url]   endpoint of the server to test
       --token [token]    token for testing authenticated calls
-      --asyncchecktime [ms] time client waits every cycle of checking state of async methods 
+      --asyncchecktime [ms] time client waits every cycle of checking state of async methods
       -h, --help         display this help message, ignore all arguments
 ";
-      
+
 # first parse options to get the testconfig file
 my $tests_filename;
 my $verbose;
@@ -38,202 +34,224 @@ my $async_job_check_time_ms;
 
 my $help;
 
-my $opt = GetOptions (
-        "tests=s" => \$tests_filename,
-        "verbose|v" => \$verbose,
-        "endpoint=s" => \$endpoint,
-        "token=s" => \$token,
-        "asyncchecktime=i" => \$async_job_check_time_ms,
-        "help|h" => \$help,
-        );
+my $opt = GetOptions(
+    "tests=s"          => \$tests_filename,
+    "verbose|v"        => \$verbose,
+    "endpoint=s"       => \$endpoint,
+    "token=s"          => \$token,
+    "asyncchecktime=i" => \$async_job_check_time_ms,
+    "help|h"           => \$help,
+);
 
-if ($help) {
-    print $DESCRIPTION."\n";
+if ( $help ) {
+    print $DESCRIPTION. "\n";
     exit 0;
 }
 
-
 # endpoint must be defined
-if (!$endpoint) {
-    fail("endpoint parameter must be defined");
+if ( !$endpoint ) {
+    fail( "endpoint parameter must be defined" );
     done_testing();
     exit 1;
 }
 
 # tests must be defined
-if (!$tests_filename) {
-    fail("tests parameter must be defined");
+if ( !$tests_filename ) {
+    fail( "tests parameter must be defined" );
     done_testing();
     exit 1;
 }
 
 #parse the tests
-open(my $fh, "<", $tests_filename);
-my $tests_string='';
-while (my $line = <$fh>) {
+open( my $fh, "<", $tests_filename );
+my $tests_string = '';
+while ( my $line = <$fh> ) {
     chomp $line;
     $tests_string .= $line;
 }
-close($fh);
-my $tests_json = JSON->new->decode($tests_string);
+close( $fh );
+my $tests_json = JSON->new->decode( $tests_string );
 
-my $tests = $tests_json->{tests};
-my $client_module = $tests_json->{package};
+my $tests         = $tests_json->{ tests };
+my $client_module = $tests_json->{ package };
 
-if (!$tests) {
-    fail("tests array not defined in test config file");
+if ( !$tests ) {
+    fail( "tests array not defined in test config file" );
     done_testing();
     exit 1;
 }
-if (!$client_module) {
-    fail("client module not defined in test config file");
+if ( !$client_module ) {
+    fail( "client module not defined in test config file" );
     done_testing();
     exit 1;
 }
 
 # make sure we can import the module
 my $json = JSON->new->canonical;
-use_ok($client_module);
+use_ok( $client_module );
 
 #instantiate an authenticated client and a nonauthenticated client
-my $nonauthenticated_client = $client_module->new($endpoint,ignore_kbase_config=>1);
-ok(defined($nonauthenticated_client),"instantiating nonauthenticated client");
+my $nonauthenticated_client = $client_module->new( $endpoint, ignore_kbase_config => 1 );
+ok( defined( $nonauthenticated_client ), "instantiating nonauthenticated client" );
 
 my $authenticated_client;
-if($token) {
-    if ($async_job_check_time_ms) {
-        $authenticated_client=$client_module->new($endpoint, token=>$token, async_job_check_time_ms=>$async_job_check_time_ms);
-    } else {
-        $authenticated_client=$client_module->new($endpoint, token=>$token);
+if ( $token ) {
+    if ( $async_job_check_time_ms ) {
+        $authenticated_client = $client_module->new(
+            $endpoint,
+            token                   => $token,
+            async_job_check_time_ms => $async_job_check_time_ms
+        );
     }
-    ok(defined($authenticated_client),"instantiating authenticated client");
+    else {
+        $authenticated_client = $client_module->new( $endpoint, token => $token );
+    }
+    ok( defined( $authenticated_client ), "instantiating authenticated client" );
 }
 
 # loop over each test case and run it against the server.  We create a new client instance
 # for each test
-foreach my $test (@{$tests}) {
+foreach my $test ( @{ $tests } ) {
     my $client;
-    if ($test->{'auth'}) {
-        if ($authenticated_client) {
+    if ( $test->{ 'auth' } ) {
+        if ( $authenticated_client ) {
             $client = $authenticated_client;
-        } else {
-            fail("authenticated call declared, but no user and password set");
+        }
+        else {
+            fail( "authenticated call declared, but no user and password set" );
             done_testing();
             exit 1;
         }
-        
-    } else {
+
+    }
+    else {
         $client = $nonauthenticated_client;
     }
-    ok(defined($client),"instantiating client");
-    
-    my $method  = $test->{method};
-    my $params  = $test->{params};
-    my $outcome = $test->{outcome};
+    ok( defined( $client ), "instantiating client" );
+
+    my $method  = $test->{ method };
+    my $params  = $test->{ params };
+    my $outcome = $test->{ outcome };
     my $useScalarContext;
-    if ($test->{context} && $test->{context} eq 'scalar') {
-        $useScalarContext=1;
+    if ( $test->{ context } && $test->{ context } eq 'scalar' ) {
+        $useScalarContext = 1;
     }
-    
-    ok($client->can($method), ' ----------------- method "'.$method.'" exists ------------------------');
-    if ($client->can($method)) {
-        my (@result, $scalarResult, $failed);
+
+    ok( $client->can( $method ),
+        ' ----------------- method "' . $method . '" exists ------------------------' );
+    if ( $client->can( $method ) ) {
+        my ( @result, $scalarResult, $failed );
         {
             no strict "refs";
             eval {
-                if ($useScalarContext) {
-                    $scalarResult = $client->$method(@{$params});
-                } else {
-                    @result = $client->$method(@{$params});
+                if ( $useScalarContext ) {
+                    $scalarResult = $client->$method( @{ $params } );
+                }
+                else {
+                    @result = $client->$method( @{ $params } );
                 }
             };
-            if($@) {
+            if ( $@ ) {
                 $failed = 1;
-                if ($outcome->{status} eq 'fail') {
-                    pass('expected failure, and yes it failed');
-                } else {
-                    fail('did not expect to fail, but it did');
-                    print STDERR "Failing test of '$method', expected to pass but error thrown:\n";
-                    print STDERR $@->{message}."\n";
-                    if(defined($@->{status_line})) {print STDERR $@->{status_line}."\n" };
+                if ( $outcome->{ status } eq 'fail' ) {
+                    pass( 'expected failure, and yes it failed' );
                 }
-                
+                else {
+                    fail( 'did not expect to fail, but it did' );
+                    print STDERR
+                        "Failing test of '$method', expected to pass but error thrown:\n";
+                    print STDERR $@->{ message } . "\n";
+                    if ( defined( $@->{ status_line } ) ) {
+                        print STDERR $@->{ status_line } . "\n";
+                    }
+                }
+
                 # check that the error message contains the right message
-                if ($outcome->{error}) {
-                    my $returnedErrorMsg = $@->{message};
-                    foreach my $e (@{$outcome->{error}}) {
-                        if(index($returnedErrorMsg, $e) != -1){
-                            pass("returned error message contains $e")
-                        } else {
-                            fail("returned error message did not contain $e");
-                            print STDERR "Failing test of '$method', expected error to contain message, but it didn't:\n";
+                if ( $outcome->{ error } ) {
+                    my $returnedErrorMsg = $@->{ message };
+                    foreach my $e ( @{ $outcome->{ error } } ) {
+                        if ( index( $returnedErrorMsg, $e ) != -1 ) {
+                            pass( "returned error message contains $e" );
+                        }
+                        else {
+                            fail( "returned error message did not contain $e" );
+                            print STDERR
+                                "Failing test of '$method', expected error to contain message, but it didn't:\n";
                             print STDERR "  looking for: '$e'\n";
                             print STDERR "  got: '$returnedErrorMsg'\n";
                         }
                     }
                 }
-                
+
                 # could do more checks here for different failure modes
-                
+
             }
         }
-        if ($outcome->{status} eq 'pass') {
-            pass('expected to run successfully, and it did');
-            my ($serialized_params, $serialized_result);
-            if ($useScalarContext) {
-                $serialized_params = $json->encode([@{$params}[0]]);
-                $serialized_result = $json->encode([$scalarResult]);
-            } else {
-                $serialized_params = $json->encode($params);
-                $serialized_result = $json->encode(\@result);
+        if ( $outcome->{ status } eq 'pass' ) {
+            pass( 'expected to run successfully, and it did' );
+            my ( $serialized_params, $serialized_result );
+            if ( $useScalarContext ) {
+                $serialized_params = $json->encode( [ @{ $params }[ 0 ] ] );
+                $serialized_result = $json->encode( [ $scalarResult ] );
             }
-            
-            ok($serialized_params eq $serialized_result,"response matches input parameters");
-            
-            if ($serialized_params ne $serialized_result) {
-                print STDERR "Failing test of '$method', expected input to match output, but they don't match:\n";
-                print STDERR "  in:  ".$serialized_params."\n";
-                print STDERR "  out: ".$serialized_result."\n";
+            else {
+                $serialized_params = $json->encode( $params );
+                $serialized_result = $json->encode( \@result );
+            }
+
+            ok(
+                $serialized_params eq $serialized_result,
+                "response matches input parameters"
+            );
+
+            if ( $serialized_params ne $serialized_result ) {
+                print STDERR
+                    "Failing test of '$method', expected input to match output, but they don't match:\n";
+                print STDERR "  in:  " . $serialized_params . "\n";
+                print STDERR "  out: " . $serialized_result . "\n";
                 print STDERR "\n";
             }
-        } elsif ($outcome->{status} eq 'nomatch') {
-            pass('expected to run successfully, and it did');
-            my ($serialized_params, $serialized_result);
-            if ($useScalarContext) {
-                ok($scalarResult,"recieved a response in scalar context");
-                $serialized_params = $json->encode([@{$params}[0]]);
-                $serialized_result = $json->encode([$scalarResult]);
-            } else {
-                ok(@result,"recieved a response in array context");
-                $serialized_params = $json->encode($params);
-                $serialized_result = $json->encode(\@result);
+        }
+        elsif ( $outcome->{ status } eq 'nomatch' ) {
+            pass( 'expected to run successfully, and it did' );
+            my ( $serialized_params, $serialized_result );
+            if ( $useScalarContext ) {
+                ok( $scalarResult, "recieved a response in scalar context" );
+                $serialized_params = $json->encode( [ @{ $params }[ 0 ] ] );
+                $serialized_result = $json->encode( [ $scalarResult ] );
             }
-            
-            ok($serialized_params ne $serialized_result,"response does NOT match input parameters");
-            
-            if ($serialized_params eq $serialized_result) {
-                print STDERR "Failing test of '$method', expected input to NOT match output, but they did match:\n";
-                print STDERR "  in/out:  ".$serialized_params."\n";
+            else {
+                ok( @result, "recieved a response in array context" );
+                $serialized_params = $json->encode( $params );
+                $serialized_result = $json->encode( \@result );
+            }
+
+            ok(
+                $serialized_params ne $serialized_result,
+                "response does NOT match input parameters"
+            );
+
+            if ( $serialized_params eq $serialized_result ) {
+                print STDERR
+                    "Failing test of '$method', expected input to NOT match output, but they did match:\n";
+                print STDERR "  in/out:  " . $serialized_params . "\n";
                 print STDERR "\n";
             }
-        } elsif ($outcome->{status} eq 'fail') {
-            if (!$failed) {
-                fail('expected to fail, but it ran successfully');
+        }
+        elsif ( $outcome->{ status } eq 'fail' ) {
+            if ( !$failed ) {
+                fail( 'expected to fail, but it ran successfully' );
             }
-        } else {
-            fail('expected outcome set to "'.$outcome->{status}.'", but that is not recognized.  Outcome can only be: pass | fail | nomatch');
+        }
+        else {
+            fail(     'expected outcome set to "'
+                    . $outcome->{ status }
+                    . '", but that is not recognized.  Outcome can only be: pass | fail | nomatch'
+            );
         }
     }
 }
 
-
-
-
-
 done_testing();
-
-
-
-
 
 


### PR DESCRIPTION
Part I of some improvements I made a while back to the perl sdk app templates. I'm using the fully improved perl sdk app for the Jacobson / Cytoscape app (kb_cytoscape).

[Commit 1](https://github.com/kbase/kb_sdk/commit/420bc6b7146cdecec32585b42fd309a5aa9482f6) is almost entirely whitespace changes from running the code formatter `perltidy` over the codebase.

[Commit 2](https://github.com/kbase/kb_sdk/commit/48286f8c62e6186c4ddff7aefdfa84f1600efd00) has more simple changes, including:
- some more perltidy tidy up
- adding `use strict` and `use warnings` to all files so errors get reported
- use the correct form of class initialisation, which is `Class::Name->new`, not `new Class::Name`
- removed `$PATH` from the `$PERL5LIB` env var -- `$PATH` is for executables, `$PERL5LIB` is for libraries
- a few minor variable renamings

Note: the tests are marked as failed because this is from my own forked repo. They have passed on my repo: https://github.com/ialarmedalien/kb_sdk/tree/better_perl (note little green tick).