### PR TITLE
Remove return statement that stops kb-sdk test

### DIFF
--- a/.github/workflows/kb_sdk-actions.yml
+++ b/.github/workflows/kb_sdk-actions.yml
@@ -61,8 +61,6 @@ jobs:
           LANGUAGE_TOKEN: ${{ matrix.language }}
         run: |
           cd SampleApp
-          kb-sdk test || true
-          sed -i "s/test_token=/test_token=$KBASE_TEST_TOKEN/" test_local/test.cfg
           kb-sdk test
 
       - name: make resulting app available as artefact in case of failure
@@ -111,19 +109,9 @@ jobs:
           repository: kbaseapps/${{ matrix.app }}
           path: kbase_app
 
-      - name: prep for repo tests
-        run: |
-          cd kbase_app
-          kb-sdk test || true
-
-      - name: edit test.cfg
+      - name: run repo tests
         env:
           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
-        run: |
-          cd kbase_app
-          sed -i "s/test_token=/test_token=$KBASE_TEST_TOKEN/" test_local/test.cfg
-
-      - name: run test
         run: |
           cd kbase_app
           kb-sdk test

--- a/.github/workflows/kb_sdk-actions.yml
+++ b/.github/workflows/kb_sdk-actions.yml
@@ -95,6 +95,7 @@ jobs:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
         app: [WsLargeDataIO, KBaseReport]
+        auth: [token, env_var]
 
     steps:
       - name: Checkout
@@ -125,7 +126,23 @@ jobs:
           repository: kbaseapps/${{ matrix.app }}
           path: kbase_app
 
-      - name: run repo tests
+      - name: run repo tests, using test.cfg for auth
+        if: matrix.auth == 'token'
+        run: |
+          cd kbase_app
+          kb-sdk test || true
+
+      - name: run repo tests, using test.cfg for auth
+        if: matrix.auth == 'token'
+        env:
+          KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
+        run: |
+          cd kbase_app
+          sed -i "s/test_token=/test_token=$KBASE_TEST_TOKEN/" test_local/test.cfg
+          kb-sdk test
+
+      - name: run repo tests, using env var for auth
+        if: matrix.auth == 'env_var'
         env:
           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
         run: |

--- a/.github/workflows/kb_sdk-actions.yml
+++ b/.github/workflows/kb_sdk-actions.yml
@@ -14,6 +14,7 @@ jobs:
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
         language: [perl, python, java]
         test_type: [base, example]
+        auth: [token, env_var]
 
     steps:
       - name: Checkout
@@ -55,10 +56,25 @@ jobs:
         run: |
           kb-sdk init -l $LANGUAGE_TOKEN -u user --example SampleApp
 
-      - name: test ${{ matrix.test_type }} repo
+      - name: test ${{ matrix.test_type }} repo, using test.cfg for auth
+        if: matrix.auth == 'token'
+        run: |
+          cd SampleApp
+          kb-sdk test || true
+
+      - name: test ${{ matrix.test_type }} repo, using test.cfg for auth
+        if: matrix.auth == 'token'
         env:
           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
-          LANGUAGE_TOKEN: ${{ matrix.language }}
+        run: |
+          cd SampleApp
+          sed -i "s/test_token=/test_token=$KBASE_TEST_TOKEN/" test_local/test.cfg
+          kb-sdk test
+
+      - name: test ${{ matrix.test_type }} repo, using env var for auth
+        if: matrix.auth == 'env_var'
+        env:
+          KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
         run: |
           cd SampleApp
           kb-sdk test

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -6,6 +6,11 @@ platform.  Modules include all code, specification files, and
 documentation needed to define and run a set of methods
 in the KBase Narrative interface.
 
+VERSION: 1.2.4 (Released 09/2020)
+---------------------------------
+CHANGES:
+- `kb-sdk test` no longer dies on its first run; if the user has the KBASE_TEST_TOKEN environment variable set with their developer token, tests can be run without having to edit the test.cfg file.
+
 VERSION: 1.2.3 (Released 06/2020)
 ------------------------------------
 NEW FEATURES:

--- a/src/java/us/kbase/mobu/ModuleBuilder.java
+++ b/src/java/us/kbase/mobu/ModuleBuilder.java
@@ -49,7 +49,7 @@ public class ModuleBuilder {
     public static final String GLOBAL_SDK_HOME_ENV_VAR = "KB_SDK_HOME";
     public static final String DEFAULT_METHOD_STORE_URL = "https://appdev.kbase.us/services/narrative_method_store/rpc";
 
-    public static final String VERSION = "1.2.3";
+    public static final String VERSION = "1.2.4";
 
     public static void main(String[] args) throws Exception {
 

--- a/src/java/us/kbase/mobu/tester/ConfigLoader.java
+++ b/src/java/us/kbase/mobu/tester/ConfigLoader.java
@@ -64,7 +64,7 @@ public class ConfigLoader {
 
         if (user == null && tokenString == null) {
             throw new IllegalStateException("Error: KBase account credentials are not set in " +
-                    configPathInfo);
+                    configPathInfo + " or the KBASE_TEST_TOKEN environment variable");
         }
         authAllowInsecure = props.getProperty("auth_service_url_allow_insecure");
         ConfigurableAuthService auth = new ConfigurableAuthService(

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -127,9 +127,6 @@ public class ModuleTester {
             TemplateFormatter.formatTemplate("module_run_docker", moduleContext, runDockerSh);
         if (!testCfg.exists()) {
             TemplateFormatter.formatTemplate("module_test_cfg", moduleContext, testCfg);
-            System.out.println("Set KBase account credentials in test_local/test.cfg and then " +
-                    "test again");
-            return 1;
         }
         Properties props = new Properties();
         InputStream is = new FileInputStream(testCfg);
@@ -140,8 +137,6 @@ public class ModuleTester {
         }
 
         ConfigLoader cfgLoader = new ConfigLoader(props, true, "test_local/test.cfg", true);
-
-
         File workDir = new File(tlDir, "workdir");
         workDir.mkdir();
         File tokenFile = new File(workDir, "token");


### PR DESCRIPTION
Currently, if you run `kb-sdk test` for the first time, it will exit after creating the `test.cfg` configuration file. However, since `kb-sdk` can now extract dev tokens from the environment (specifically from the env var `KBASE_TEST_TOKEN`), it is possible for the test run to go ahead as `test.cfg` and the environment may contain all the information needed to run the tests. If there is no token in the environment or `test.cfg`, `kb-sdk test` will die with the usual message about "Error: KBase account credentials are not set...".

To test this, I have removed the steps from the GitHub actions where `test.cfg` is edited to add the test token, and just populated the environment variable instead. The tests now run without requiring the extra `kb-sdk test || true` step.

I have also edited the error message about missing KBase account credentials to state that they were not found in either `test.cfg` or the env var `KBASE_TEST_TOKEN`.