### PR TITLE
Update entrypoint script to force root user

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -6,10 +6,16 @@ platform.  Modules include all code, specification files, and
 documentation needed to define and run a set of methods
 in the KBase Narrative interface.
 
-VERSION: 1.2.4 (Released 09/2020)
+
+VERSION: 1.2.5 (Unreleased)
+---------------------------------
+- `kb-sdk test` no longer can see the docker socket due to a docker permissions issue on the docker socket. By default, the user running in the kb-sdk container now runs as the root user
+
+VERSION: 1.2.4 (Unreleased)
 ---------------------------------
 CHANGES:
 - `kb-sdk test` no longer dies on its first run; if the user has the KBASE_TEST_TOKEN environment variable set with their developer token, tests can be run without having to edit the test.cfg file.
+
 
 VERSION: 1.2.3 (Released 06/2020)
 ------------------------------------

--- a/entrypoint
+++ b/entrypoint
@@ -4,7 +4,7 @@ if [ "z$1" = "zshell" ] ; then
 elif [ "z$1" = "zsetup" ] ; then
     cat << EOF
 G=\$(docker run -i -v /var/run/docker.sock:/var/run/docker.sock --entrypoint ls kbase/kb-sdk -l /var/run/docker.sock|awk '{print \$4}');
-alias kb-sdk='docker run -it --rm -v \$HOME:\$HOME -u \$(id -u) -w \$(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL -e KBASE_TEST_TOKEN=\$KBASE_TEST_TOKEN --group-add \$G kbase/kb-sdk'
+alias kb-sdk='docker run -it --rm -v \$HOME:\$HOME -u 0 -w \$(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL -e KBASE_TEST_TOKEN=\$KBASE_TEST_TOKEN --group-add \$G kbase/kb-sdk'
 EOF
 elif [ "z$1" = "zgenscript" ] ; then
     cat << EOF
@@ -15,7 +15,7 @@ if [ ! -e \$HOME/.kbsdk.cache ] ; then
   docker run -i -v /var/run/docker.sock:/var/run/docker.sock --entrypoint ls kbase/kb-sdk -l /var/run/docker.sock|awk '{print \$4}' > \$HOME/.kbsdk.cache
 fi
 
-exec docker run -it --rm -v \$HOME:\$HOME -u \$(id -u) -w \$(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL -e KBASE_TEST_TOKEN=\$KBASE_TEST_TOKEN --group-add \$(cat \$HOME/.kbsdk.cache) kbase/kb-sdk \$@
+exec docker run -it --rm -v \$HOME:\$HOME -u 0 -w \$(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL -e KBASE_TEST_TOKEN=\$KBASE_TEST_TOKEN --group-add \$(cat \$HOME/.kbsdk.cache) kbase/kb-sdk \$@
 EOF
 elif [ "z$1" = "zprune" ] ; then
   echo "Used during build to shrink image.  Not needed by the user."

--- a/src/java/us/kbase/mobu/ModuleBuilder.java
+++ b/src/java/us/kbase/mobu/ModuleBuilder.java
@@ -49,7 +49,7 @@ public class ModuleBuilder {
     public static final String GLOBAL_SDK_HOME_ENV_VAR = "KB_SDK_HOME";
     public static final String DEFAULT_METHOD_STORE_URL = "https://appdev.kbase.us/services/narrative_method_store/rpc";
 
-    public static final String VERSION = "1.2.4";
+    public static final String VERSION = "1.2.5";
 
     public static void main(String[] args) throws Exception {
 


### PR DESCRIPTION
Since the new mac osx update, kb-sdk no longer properly works. The user inside the kb-sdk container doesn't have permissions to the docker socket. 

* Possible side effects are having to use `sudo su` to  to delete the files that appear on your machine