### PR TITLE
Removing "-t" flag to allow github actions to run kb-sdk

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -6,6 +6,10 @@ platform.  Modules include all code, specification files, and
 documentation needed to define and run a set of methods
 in the KBase Narrative interface.
 
+VERSION: 1.2.6 (Released 10/2020)
+---------------------------------
+CHANGES:
+- "-t" flag removed from entrypoint commands to enable kb-sdk to be run by github actions.
 
 VERSION: 1.2.5 (Unreleased)
 ---------------------------------

--- a/entrypoint
+++ b/entrypoint
@@ -4,7 +4,7 @@ if [ "z$1" = "zshell" ] ; then
 elif [ "z$1" = "zsetup" ] ; then
     cat << EOF
 G=\$(docker run -i -v /var/run/docker.sock:/var/run/docker.sock --entrypoint ls kbase/kb-sdk -l /var/run/docker.sock|awk '{print \$4}');
-alias kb-sdk='docker run -it --rm -v \$HOME:\$HOME -u 0 -w \$(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL -e KBASE_TEST_TOKEN=\$KBASE_TEST_TOKEN --group-add \$G kbase/kb-sdk'
+alias kb-sdk='docker run -i --rm -v \$HOME:\$HOME -u 0 -w \$(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL -e KBASE_TEST_TOKEN=\$KBASE_TEST_TOKEN --group-add \$G kbase/kb-sdk'
 EOF
 elif [ "z$1" = "zgenscript" ] ; then
     cat << EOF
@@ -15,7 +15,7 @@ if [ ! -e \$HOME/.kbsdk.cache ] ; then
   docker run -i -v /var/run/docker.sock:/var/run/docker.sock --entrypoint ls kbase/kb-sdk -l /var/run/docker.sock|awk '{print \$4}' > \$HOME/.kbsdk.cache
 fi
 
-exec docker run -it --rm -v \$HOME:\$HOME -u 0 -w \$(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL -e KBASE_TEST_TOKEN=\$KBASE_TEST_TOKEN --group-add \$(cat \$HOME/.kbsdk.cache) kbase/kb-sdk \$@
+exec docker run -i --rm -v \$HOME:\$HOME -u 0 -w \$(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=\$USER -e DSHELL=\$SHELL -e KBASE_TEST_TOKEN=\$KBASE_TEST_TOKEN --group-add \$(cat \$HOME/.kbsdk.cache) kbase/kb-sdk \$@
 EOF
 elif [ "z$1" = "zprune" ] ; then
   echo "Used during build to shrink image.  Not needed by the user."

--- a/src/java/us/kbase/mobu/ModuleBuilder.java
+++ b/src/java/us/kbase/mobu/ModuleBuilder.java
@@ -49,8 +49,8 @@ public class ModuleBuilder {
     public static final String GLOBAL_SDK_HOME_ENV_VAR = "KB_SDK_HOME";
     public static final String DEFAULT_METHOD_STORE_URL = "https://appdev.kbase.us/services/narrative_method_store/rpc";
 
-    public static final String VERSION = "1.2.5";
-    
+    public static final String VERSION = "1.2.6";
+
     public static void main(String[] args) throws Exception {
 
         // set up the basic CLI argument parser with global -h and --help commands


### PR DESCRIPTION
GitHub Actions cannot run kb-sdk when it is in a docker container because the `entrypoint` script adds the `-t` flag to the docker command (to add a TTY-type interface to the container), which causes GitHub Actions to error out. Since the commands that the entry point script is adding can't be run interactively, the `-t` flag can be safely removed.