### PR TITLE
Updating Dockerfile to enable `docker buildx`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get -y update && \
     $(lsb_release -cs) \
     stable" && \
     apt-get -y update && \
-    apt-get -y install docker-ce docker-ce-cli containerd.io
+    apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
 # Add kb-sdk src and fix CallbackServer interface
 ADD . /src


### PR DESCRIPTION
#### Summary
This pull request simply updates the docker install line to: 
``apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin``

#### Justification
As part of [DEVOPS-765](https://kbase-jira.atlassian.net/browse/DEVOPS-765), we're creating custom workflows for some repos (e.g. [sample_service](https://github.com/kbase/sample_service/)) to run `make compile`, which triggers the `kb-sdk compile` step.

The easiest way to make this work is to simply build using the `kbase/kb-sdk` image vs the stock `ubuntu-latest` image.
Since the custom workflows in question are based on our reusable workflows, they need the ability to build using the `docker buildx` command.

#### Testing
- A test version of kb-sdk was build using the proposed Dockerfile, and pushed to [jsfillman/kb-sdk](https://hub.docker.com/repository/docker/jsfillman/kb-sdk).
- The reusable workflows were modified to utilize this image and run `make compile` in the [kbase/sdk-compile-test](https://github.com/kbase/sdk-compile-test) repo, which is a copy of `kbase/sample_service`.
- All relevant workflows were tested:
  - ✅ Pull Request Build, Tag, & Push
  - ✅ Build Production Release Image
  - ✅ Manual Build & Push

[DEVOPS-765]: https://kbase-jira.atlassian.net/browse/DEVOPS-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ