### PR TITLE
DEVOPS-1197: Add GHA actions

### DIFF
--- a/.github/workflows/kb_sdk-actions.yml
+++ b/.github/workflows/kb_sdk-actions.yml
@@ -1,187 +1,187 @@
-name: Basic kb-sdk tests
+# name: Basic kb-sdk tests
 
-on:
-  [push, pull_request]
+# on:
+#   [push, pull_request]
 
-jobs:
+# jobs:
 
-  test_kb-sdk_builds:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
-        language: [perl, python, java]
-        test_type: [base, example]
-        auth: [token, env_var]
+#   test_kb-sdk_builds:
+#     if: "!contains(github.event.head_commit.message, 'skip ci')"
+#     runs-on: ${{ matrix.os }}
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+#         language: [perl, python, java]
+#         test_type: [base, example]
+#         auth: [token, env_var]
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
+#       - name: Set up JDK 1.8
+#         uses: actions/setup-java@v1
+#         with:
+#           java-version: 1.8
 
-      - name: Build with Ant
-        run: |
-          make
+#       - name: Build with Ant
+#         run: |
+#           make
 
-      - name: Add bin to $PATH
-        run: |
-          echo "::add-path::$GITHUB_WORKSPACE/bin"
+#       - name: Add bin to $PATH
+#         run: |
+#           echo "::add-path::$GITHUB_WORKSPACE/bin"
 
-      - name: checking kb-sdk functions
-        env:
-          KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
-          LANGUAGE_TOKEN: ${{ matrix.language }}
-        run: |
-          env
-          kb-sdk help
-          kb-sdk version
+#       - name: checking kb-sdk functions
+#         env:
+#           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
+#           LANGUAGE_TOKEN: ${{ matrix.language }}
+#         run: |
+#           env
+#           kb-sdk help
+#           kb-sdk version
 
-      - name: init base repo
-        if: matrix.test_type == 'base'
-        env:
-          LANGUAGE_TOKEN: ${{ matrix.language }}
-        run: |
-          kb-sdk init -l $LANGUAGE_TOKEN -u user SampleApp
+#       - name: init base repo
+#         if: matrix.test_type == 'base'
+#         env:
+#           LANGUAGE_TOKEN: ${{ matrix.language }}
+#         run: |
+#           kb-sdk init -l $LANGUAGE_TOKEN -u user SampleApp
 
-      - name: init example repo
-        if: matrix.test_type == 'example'
-        env:
-          LANGUAGE_TOKEN: ${{ matrix.language }}
-        run: |
-          kb-sdk init -l $LANGUAGE_TOKEN -u user --example SampleApp
+#       - name: init example repo
+#         if: matrix.test_type == 'example'
+#         env:
+#           LANGUAGE_TOKEN: ${{ matrix.language }}
+#         run: |
+#           kb-sdk init -l $LANGUAGE_TOKEN -u user --example SampleApp
 
-      - name: test ${{ matrix.test_type }} repo, using test.cfg for auth
-        if: matrix.auth == 'token'
-        run: |
-          cd SampleApp
-          kb-sdk test || true
+#       - name: test ${{ matrix.test_type }} repo, using test.cfg for auth
+#         if: matrix.auth == 'token'
+#         run: |
+#           cd SampleApp
+#           kb-sdk test || true
 
-      - name: test ${{ matrix.test_type }} repo, using test.cfg for auth
-        if: matrix.auth == 'token'
-        env:
-          KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
-        run: |
-          cd SampleApp
-          sed -i "s/test_token=/test_token=$KBASE_TEST_TOKEN/" test_local/test.cfg
-          kb-sdk test
+#       - name: test ${{ matrix.test_type }} repo, using test.cfg for auth
+#         if: matrix.auth == 'token'
+#         env:
+#           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
+#         run: |
+#           cd SampleApp
+#           sed -i "s/test_token=/test_token=$KBASE_TEST_TOKEN/" test_local/test.cfg
+#           kb-sdk test
 
-      - name: test ${{ matrix.test_type }} repo, using env var for auth
-        if: matrix.auth == 'env_var'
-        env:
-          KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
-        run: |
-          cd SampleApp
-          kb-sdk test
+#       - name: test ${{ matrix.test_type }} repo, using env var for auth
+#         if: matrix.auth == 'env_var'
+#         env:
+#           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
+#         run: |
+#           cd SampleApp
+#           kb-sdk test
 
-      - name: make resulting app available as artefact in case of failure
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: kbaseapp-${{ matrix.language }}-${{ matrix.test_type }}-${{ matrix.os }}
-          path: SampleApp
+#       - name: make resulting app available as artefact in case of failure
+#         if: ${{ failure() }}
+#         uses: actions/upload-artifact@v2
+#         with:
+#           name: kbaseapp-${{ matrix.language }}-${{ matrix.test_type }}-${{ matrix.os }}
+#           path: SampleApp
 
 
-  test_existing_repos:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
-        app: [WsLargeDataIO, KBaseReport]
-        auth: [token, env_var]
+#   test_existing_repos:
+#     if: "!contains(github.event.head_commit.message, 'skip ci')"
+#     runs-on: ${{ matrix.os }}
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+#         app: [WsLargeDataIO, KBaseReport]
+#         auth: [token, env_var]
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
+#       - name: Set up JDK 1.8
+#         uses: actions/setup-java@v1
+#         with:
+#           java-version: 1.8
 
-      - name: Build with Ant
-        run: |
-          make
+#       - name: Build with Ant
+#         run: |
+#           make
 
-      - name: Add bin to $PATH
-        run: |
-          echo "::add-path::$GITHUB_WORKSPACE/bin"
+#       - name: Add bin to $PATH
+#         run: |
+#           echo "::add-path::$GITHUB_WORKSPACE/bin"
 
-      - name: checking basic kb-sdk functions
-        run: |
-          env
-          kb-sdk help
-          kb-sdk version
+#       - name: checking basic kb-sdk functions
+#         run: |
+#           env
+#           kb-sdk help
+#           kb-sdk version
 
-      - name: Checkout existing kbase module ${{ matrix.app }}
-        uses: actions/checkout@v2
-        with:
-          repository: kbaseapps/${{ matrix.app }}
-          path: kbase_app
+#       - name: Checkout existing kbase module ${{ matrix.app }}
+#         uses: actions/checkout@v2
+#         with:
+#           repository: kbaseapps/${{ matrix.app }}
+#           path: kbase_app
 
-      - name: run repo tests, using test.cfg for auth
-        if: matrix.auth == 'token'
-        run: |
-          cd kbase_app
-          kb-sdk test || true
+#       - name: run repo tests, using test.cfg for auth
+#         if: matrix.auth == 'token'
+#         run: |
+#           cd kbase_app
+#           kb-sdk test || true
 
-      - name: run repo tests, using test.cfg for auth
-        if: matrix.auth == 'token'
-        env:
-          KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
-        run: |
-          cd kbase_app
-          sed -i "s/test_token=/test_token=$KBASE_TEST_TOKEN/" test_local/test.cfg
-          kb-sdk test
+#       - name: run repo tests, using test.cfg for auth
+#         if: matrix.auth == 'token'
+#         env:
+#           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
+#         run: |
+#           cd kbase_app
+#           sed -i "s/test_token=/test_token=$KBASE_TEST_TOKEN/" test_local/test.cfg
+#           kb-sdk test
 
-      - name: run repo tests, using env var for auth
-        if: matrix.auth == 'env_var'
-        env:
-          KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
-        run: |
-          cd kbase_app
-          kb-sdk test
+#       - name: run repo tests, using env var for auth
+#         if: matrix.auth == 'env_var'
+#         env:
+#           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
+#         run: |
+#           cd kbase_app
+#           kb-sdk test
 
-      - name: make resulting app available as artefact in case of failure
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: kbaseapp-${{ matrix.app }}-${{ matrix.os }}
-          path: kbase_app
+#       - name: make resulting app available as artefact in case of failure
+#         if: ${{ failure() }}
+#         uses: actions/upload-artifact@v2
+#         with:
+#           name: kbaseapp-${{ matrix.app }}-${{ matrix.os }}
+#           path: kbase_app
 
-  dockerhub_upload:
-    runs-on: ubuntu-latest
-    if: |
-      (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') &&
-      github.event_name == 'push' &&
-      !contains(github.event.head_commit.message, 'skip docker') &&
-      !contains(github.event.head_commit.message, 'skip ci')
-    needs:
-      - test_existing_repos
-      - test_kb-sdk_builds
+#   dockerhub_upload:
+#     runs-on: ubuntu-latest
+#     if: |
+#       (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') &&
+#       github.event_name == 'push' &&
+#       !contains(github.event.head_commit.message, 'skip docker') &&
+#       !contains(github.event.head_commit.message, 'skip ci')
+#     needs:
+#       - test_existing_repos
+#       - test_kb-sdk_builds
 
-    steps:
-    - name: checkout git repo
-      uses: actions/checkout@v2
+#     steps:
+#     - name: checkout git repo
+#       uses: actions/checkout@v2
 
-    - name: set current branch name as TAG_NAME for docker image
-      shell: bash
-      run: echo "::set-env name=TAG_NAME::${GITHUB_REF#refs/heads/}"
+#     - name: set current branch name as TAG_NAME for docker image
+#       shell: bash
+#       run: echo "::set-env name=TAG_NAME::${GITHUB_REF#refs/heads/}"
 
-    - name: build and push to dockerhub
-      uses: opspresso/action-docker@master
-      with:
-        args: --docker
-      env:
-        USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        DOCKERFILE: "Dockerfile"
-        IMAGE_NAME: "kbase/kb-sdk"
+#     - name: build and push to dockerhub
+#       uses: opspresso/action-docker@master
+#       with:
+#         args: --docker
+#       env:
+#         USERNAME: ${{ secrets.DOCKER_USERNAME }}
+#         PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+#         DOCKERFILE: "Dockerfile"
+#         IMAGE_NAME: "kbase/kb-sdk"
 

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -1,0 +1,11 @@
+---
+name: Manual Build & Push
+on:
+ workflow_dispatch:
+jobs:
+  build-push:
+    uses: kbase/.github/.github/workflows/reusable_build-push.yml@main
+    with:
+      name: '${{ github.event.repository.name }}-develop'
+      tags: br-${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,0 +1,43 @@
+---
+name: Pull Request Build, Tag, & Push
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+jobs:
+  build-develop-open:
+    if: github.base_ref == 'develop' && github.event.pull_request.merged == false
+    uses: kbase/.github/.github/workflows/reusable_build.yml@main
+    secrets: inherit
+  build-develop-merge:
+    if: github.base_ref == 'develop' && github.event.pull_request.merged == true
+    uses: kbase/.github/.github/workflows/reusable_build-push.yml@main
+    with:
+      name: '${{ github.event.repository.name }}-develop'
+      tags: pr-${{ github.event.number }},latest
+    secrets: inherit
+  build-main-open:
+    if: (github.base_ref == 'main' || github.base_ref == 'master') && github.event.pull_request.merged == false
+    uses: kbase/.github/.github/workflows/reusable_build-push.yml@main
+    with:
+      name: '${{ github.event.repository.name }}'
+      tags: pr-${{ github.event.number }}
+    secrets: inherit
+  build-main-merge:
+    if: (github.base_ref == 'main' || github.base_ref == 'master') && github.event.pull_request.merged == true
+    uses: kbase/.github/.github/workflows/reusable_build-push.yml@main
+    with:
+      name: '${{ github.event.repository.name }}'
+      tags: pr-${{ github.event.number }},latest-rc
+    secrets: inherit
+  trivy-scans:
+    if: (github.base_ref == 'develop' || github.base_ref == 'main' || github.base_ref == 'master' ) && github.event.pull_request.merged == false
+    uses: kbase/.github/.github/workflows/reusable_trivy-scans.yml@main
+    secrets: inherit

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -1,0 +1,25 @@
+---
+name: Release - Build & Push Image
+on:
+  release:
+    branches:
+      - main
+      - master
+    types: [ published ]
+jobs:
+  check-source-branch:
+    uses: kbase/.github/.github/workflows/reusable_validate-branch.yml@main
+    with:
+      build_branch: '${{ github.event.release.target_commitish }}'
+  validate-release-tag:
+    needs: check-source-branch
+    uses: kbase/.github/.github/workflows/reusable_validate-release-tag.yml@main
+    with:
+      release_tag: '${{ github.event.release.tag_name }}'
+  build-push:
+    needs: validate-release-tag
+    uses: kbase/.github/.github/workflows/reusable_build-push.yml@main
+    with:
+      name: '${{ github.event.repository.name }}'
+      tags: '${{ github.event.release.tag_name }},latest'
+    secrets: inherit


### PR DESCRIPTION
* Adds github actions to build images for prs, releases and manual builds
* Temporarily disabling GHA Tests due to
```
Error: Unable to process command '::add-path::/home/runner/work/kb_sdk/kb_sdk/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```