### PR TITLE
Pass Token Via File

### DIFF
--- a/src/java/us/kbase/templates/module_run_async.vm.properties
+++ b/src/java/us/kbase/templates/module_run_async.vm.properties
@@ -2,7 +2,7 @@ script_dir=$(dirname "$(readlink -f "$0")")
 export KB_DEPLOYMENT_CONFIG=$script_dir/../deploy.cfg
 WD=/kb/module/work
 if [ -f $WD/token ]; then
-    cat $WD/token | xargs sh $script_dir/../bin/run_${module_name}_async_job.sh $WD/input.json $WD/output.json
+    xargs sh $script_dir/../bin/run_${module_name}_async_job.sh $WD/input.json $WD/output.json $WD/token
 else
     echo "File $WD/token doesn't exist, aborting."
     exit 1


### PR DESCRIPTION
* Pass token via file rather than the command line args, so you cannot see the token with `ps`
* Related https://github.com/kbaseapps/kbase_hipmer/pull/19